### PR TITLE
Fix GitHub Actions permissions for forked repositories

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -218,7 +218,7 @@ jobs:
         MOST_RECENT_TAG: ${{ env.MOST_RECENT_TAG }}
 
     - name: Create v0.0.1 tag if no tag exists
-      if: env.MOST_RECENT_TAG == ''
+      if: env.MOST_RECENT_TAG == '' && github.event.repository.fork == false
       run: |
         git config user.name "github-actions"
         git config user.email "github-actions@github.com"
@@ -232,8 +232,16 @@ jobs:
           echo "MOST_RECENT_TAG=v0.0.1" >> $GITHUB_ENV
         fi
 
-    - name: Create release for most recent tag if missing
-      if: env.MOST_RECENT_TAG != '' && steps.tag-check.outputs.release_exists == 'false'
+    - name: Set fallback tag for forks
+      if: env.MOST_RECENT_TAG == '' && github.event.repository.fork == true
+      run: |
+        echo "Running on a fork, using fallback tag naming"
+        TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+        FALLBACK_TAG="fork-build-${TIMESTAMP}"
+        echo "MOST_RECENT_TAG=${FALLBACK_TAG}" >> $GITHUB_ENV
+
+    - name: Create release for most recent tag if missing (non-fork only)
+      if: env.MOST_RECENT_TAG != '' && steps.tag-check.outputs.release_exists == 'false' && github.event.repository.fork == false
       run: |
         gh release create "${MOST_RECENT_TAG}" \
           release/*.pdf \
@@ -244,7 +252,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         MOST_RECENT_TAG: ${{ env.MOST_RECENT_TAG }}
 
-    - name: Create or update most recent tag release
+    - name: Create or update most recent tag release (non-fork only)
+      if: github.event.repository.fork == false
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ env.MOST_RECENT_TAG }}
@@ -271,3 +280,21 @@ jobs:
         files: |
           release/*.pdf
           release/build_info.txt
+
+    - name: Fork notification
+      if: github.event.repository.fork == true
+      run: |
+        echo "=================================================="
+        echo "🍴 Fork Repository Detected"
+        echo "=================================================="
+        echo "This workflow is running on a forked repository."
+        echo "PDF has been generated and uploaded as an artifact."
+        echo "To access your PDF:"
+        echo "1. Go to the Actions tab of your fork"
+        echo "2. Click on this workflow run"
+        echo "3. Download the 'generated-pdf' artifact"
+        echo ""
+        echo "Note: Releases cannot be created on forks due to"
+        echo "GitHub permissions. The PDF is available as an"
+        echo "workflow artifact for 90 days."
+        echo "=================================================="

--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ Works with **both public and private repositories**:
 3. **Push changes** → PDF automatically generated
 4. **Download PDF** from Actions tab or Releases
 
+**📌 Important for Forks**: 
+- Forked repositories have limited GitHub Actions permissions
+- PDFs are generated and available as **workflow artifacts** (not releases)
+- To access your PDF: Go to Actions tab → Click workflow run → Download "generated-pdf" artifact
+- Artifacts are retained for 90 days
+
 #### 3️⃣ **Google Colab** (No Installation)
 Perfect for quick testing and collaboration:
 - Click the Colab badge above


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow failing on forks due to permission denied errors
- Add proper fork detection and handling in CI/CD pipeline
- Update documentation with clear fork usage instructions

## Changes Made
- **GitHub Actions workflow** (`.github/workflows/build-pdf.yml`):
  - Add fork detection using `github.event.repository.fork`
  - Skip tag creation and release publishing on forks
  - Add fallback tag naming for fork builds with timestamps
  - Include clear notification for fork users with artifact access instructions
- **README documentation**:
  - Add dedicated section explaining fork limitations and workarounds
  - Clear step-by-step instructions for accessing PDFs from workflow artifacts
  - Document 90-day artifact retention period

## Problem Solved
Resolves issue #9 where users reported "Permission denied to github-actions[bot]" errors when running the workflow on forked repositories. The error occurred because:
- Forks have limited GitHub Actions permissions
- Cannot push tags or create releases
- Previous workflow assumed full repository permissions

## Solution Implementation
The workflow now handles both scenarios:
- **Original repository**: Full functionality with tags and releases
- **Forked repository**: PDF generation with artifact download (no permission errors)

## Testing
- Workflow successfully detects fork status
- PDFs are generated and available as artifacts for fork users
- Original functionality preserved for main repository

🤖 Generated with [Claude Code](https://claude.ai/code)