### PR TITLE
docs: add troubleshooting guide for missing figure files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,4 @@ cython_debug/
 .gitignore
 MANUSCRIPT/2025__author_et_al__rxiv.pdf
 EXAMPLE_MANUSCRIPT/2025__Saraiva_et_al__for_arxiv.zip
+GEMINI.md

--- a/docs/troubleshooting-missing-figures.md
+++ b/docs/troubleshooting-missing-figures.md
@@ -1,0 +1,51 @@
+# Troubleshooting: Missing Figure Files
+
+## Problem: PDF Generation Fails Due to Missing PNG Files
+
+### Symptoms
+- `make pdf` fails with validation errors
+- Error messages like: "Figure file not found: FIGURES/example_figure/example_figure.png"
+- The validation shows missing PNG files in MANUSCRIPT/FIGURES/ subdirectories
+
+### Root Cause
+The repository tracks generated PNG files alongside their Python generation scripts. If these PNG files are accidentally deleted (e.g., by `make clean`, manual deletion, or git operations), the build process will fail because the LaTeX compilation expects these files to exist.
+
+### Solution
+Regenerate the missing PNG files by running the corresponding Python scripts:
+
+```bash
+# Navigate to the FIGURES directory
+cd MANUSCRIPT/FIGURES
+
+# Activate the virtual environment
+source ../../.venv/bin/activate
+
+# Run the figure generation scripts
+python example_figure.py
+python supplementary_figure.py
+
+# Return to project root and test the build
+cd ../..
+make pdf
+```
+
+### Prevention
+- The `make clean` command removes generated figures, so always run `make pdf` (not just `make validate`) after cleaning
+- When cloning the repository, ensure all tracked PNG files are properly downloaded
+- If using figure generation scripts, understand that their outputs are tracked in git
+
+### Automated Figure Generation
+For a more robust solution, you can use the built-in figure generation command:
+
+```bash
+# Generate all figures automatically
+source .venv/bin/activate
+python src/py/commands/generate_figures.py --figures-dir MANUSCRIPT/FIGURES --verbose
+```
+
+### Why PNG Files Are Tracked
+Unlike typical development practices where generated files are ignored, Rxiv-Maker tracks the generated PNG files because:
+- They ensure reproducible builds across different environments
+- Not all users have the Python dependencies needed for figure generation
+- LaTeX compilation requires these files to exist
+- They serve as fallbacks when figure generation scripts fail


### PR DESCRIPTION
## Summary
- Add comprehensive troubleshooting documentation for missing figure file issues
- Addresses common build failures when PNG files are accidentally deleted
- Provides step-by-step solutions and prevention strategies

## Problem Addressed
Users frequently encounter PDF generation failures with errors like:
```
Figure file not found: FIGURES/example_figure/example_figure.png
```

This occurs when tracked PNG files in `MANUSCRIPT/FIGURES/` are missing, causing LaTeX compilation to fail.

## Solution
Created `docs/troubleshooting-missing-figures.md` with:
- **Problem identification**: Clear symptoms and error messages
- **Root cause explanation**: Why PNG files are tracked and required
- **Step-by-step solution**: Manual regeneration process
- **Prevention strategies**: Best practices to avoid the issue
- **Automated options**: Using built-in figure generation commands
- **Design rationale**: Why Rxiv-Maker tracks generated files

## Test plan
- [x] Verify the troubleshooting steps resolve the missing figure issue
- [x] Confirm `make pdf` works after following the documented solution
- [x] Test figure regeneration scripts function correctly
- [x] Validate documentation is clear and comprehensive

🤖 Generated with [Claude Code](https://claude.ai/code)