### PR TITLE
🔧 Fix workflow permissions for APT repository

### DIFF
--- a/.github/workflows/release-simple.yml
+++ b/.github/workflows/release-simple.yml
@@ -372,6 +372,10 @@ jobs:
     uses: ./.github/workflows/publish-apt.yml
     needs: [build, pypi]
     if: needs.pypi.result == 'success' && !inputs.dry-run
+    permissions:
+      contents: write  # Required for pushing to apt-repo branch
+      pages: write     # Required for GitHub Pages deployment
+      id-token: write  # Required for OIDC attestations
     with:
       version: ${{ needs.build.outputs.version }}
       dry-run: false

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,6 +1,6 @@
 """Version information for rxiv-maker."""
 
-__version__ = "1.5.11"
+__version__ = "1.5.12"
 __version_tuple__ = (1, 5, 8)
 
 # Note: Docker images v1.8+ use mermaid.ink API for diagram processing


### PR DESCRIPTION
## Summary
- Fix permissions issue preventing APT repository workflow from running
- Resolves startup failure in release workflow v1.5.12

## Changes
- Add required `contents: write`, `pages: write`, and `id-token: write` permissions to apt-repository job
- Enables successful calling of `publish-apt.yml` reusable workflow
- Required for pushing to apt-repo branch and GitHub Pages deployment

## Testing
- Fixes the workflow startup failure in release run #14
- Enables complete APT repository testing workflow

🤖 Generated with [Claude Code](https://claude.ai/code)