### PR TITLE
🔧 Simplify APT workflow permissions

### DIFF
--- a/.github/workflows/release-simple.yml
+++ b/.github/workflows/release-simple.yml
@@ -374,8 +374,6 @@ jobs:
     if: needs.pypi.result == 'success' && !inputs.dry-run
     permissions:
       contents: write  # Required for pushing to apt-repo branch
-      pages: write     # Required for GitHub Pages deployment
-      id-token: write  # Required for OIDC attestations
     with:
       version: ${{ needs.build.outputs.version }}
       dry-run: false

--- a/.github/workflows/release-simple.yml
+++ b/.github/workflows/release-simple.yml
@@ -372,6 +372,10 @@ jobs:
     uses: ./.github/workflows/publish-apt.yml
     needs: [build, pypi]
     if: needs.pypi.result == 'success' && !inputs.dry-run
+    permissions:
+      contents: write  # Required for pushing to apt-repo branch
+      pages: write     # Required for GitHub Pages deployment
+      id-token: write  # Required for OIDC attestations
     with:
       version: ${{ needs.build.outputs.version }}
       dry-run: false

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,6 +1,6 @@
 """Version information for rxiv-maker."""
 
-__version__ = "1.5.11"
+__version__ = "1.5.12"
 __version_tuple__ = (1, 5, 8)
 
 # Note: Docker images v1.8+ use mermaid.ink API for diagram processing


### PR DESCRIPTION
## Summary
- Remove unnecessary permissions from APT repository workflow
- APT repository uses raw GitHub repo approach via apt-repo branch, not GitHub Pages

## Changes
- Remove `pages: write` and `id-token: write` permissions
- Keep only `contents: write` permission for pushing to apt-repo branch
- Aligns permissions with actual workflow requirements

## Context
The APT repository publishes packages via raw GitHub repository serving at:
`https://raw.githubusercontent.com/henriqueslab/rxiv-maker/apt-repo/`

This approach doesn't require GitHub Pages or OIDC permissions.

🤖 Generated with [Claude Code](https://claude.ai/code)