### PR TITLE
fix: PyPI logo and metadata improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Rxiv-Maker
 
-<img src="src/logo/logo-rxiv-maker.svg" align="right" width="200" style="margin-left: 20px;"/>
+<img src="https://raw.githubusercontent.com/HenriquesLab/rxiv-maker/main/src/logo/logo-rxiv-maker.svg" align="right" width="200" style="margin-left: 20px;"/>
 
 **Write scientific preprints in Markdown. Generate publication-ready PDFs efficiently.**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,18 @@ classifiers = [
     "Topic :: Text Processing :: Markup :: LaTeX",
     "Topic :: Text Processing :: Markup :: Markdown",
 ]
-description = "Automated LaTeX article generation with modern CLI and figure creation capabilities"
+description = "Write scientific preprints in Markdown. Generate publication-ready PDFs efficiently."
 readme = "README.md"
 requires-python = ">=3.10"
+
+[project.urls]
+Homepage = "https://github.com/HenriquesLab/rxiv-maker"
+Documentation = "https://github.com/HenriquesLab/rxiv-maker#readme"
+Repository = "https://github.com/HenriquesLab/rxiv-maker"
+Issues = "https://github.com/HenriquesLab/rxiv-maker/issues"
+Changelog = "https://github.com/HenriquesLab/rxiv-maker/blob/main/CHANGELOG.md"
+"Bug Reports" = "https://github.com/HenriquesLab/rxiv-maker/issues"
+"Source Code" = "https://github.com/HenriquesLab/rxiv-maker"
 dependencies = [
     # Core scientific libraries for figure generation (optional for users who don't generate figures)
     "matplotlib>=3.7.0",


### PR DESCRIPTION
## Summary

Fixes the PyPI logo rendering issue and improves project metadata display.

## Changes

- **🔧 Add project URLs** to  for better PyPI sidebar with links to:
  - Homepage, Documentation, Repository
  - Issues, Changelog, Bug Reports, Source Code
- **🖼️ Fix logo display** by changing README logo path from relative () to absolute GitHub URL
- **📝 Update project description** to match the main tagline for consistency

## Why This Fixes the Logo Issue

PyPI can't access relative file paths in README files. The logo needs to be referenced via an absolute URL that PyPI can fetch, such as GitHub's raw content URL.

## Testing

The logo should now display properly on the PyPI project page after the next release.

## Before/After

**Before:** Broken logo display on PyPI, minimal project metadata  
**After:** Working logo display, rich project sidebar with useful links

Fixes the issue reported in the conversation where the logo was not rendering on PyPI.