### PR TITLE
chore: disable scheduled documentation link check

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -15,9 +15,10 @@ on:
       - '*.md'
       - '.github/workflows/docs-link-check.yml'
       - 'scripts/check-docs-links.py'
-  schedule:
+  # schedule:
     # Run weekly on Mondays at 9 AM UTC
-    - cron: '0 9 * * 1'
+    # Disabled until script is fixed to avoid false positives
+    # - cron: '0 9 * * 1'
   workflow_dispatch:
     inputs:
       verbose:


### PR DESCRIPTION
## Summary

Disable the weekly scheduled run of the documentation link checker until the script is fixed.

## Problem

The link checker script generates false positives (see #173):
- Reports files as missing when they actually exist
- Bug: checks link text instead of link target
- Example: link `[core.cache.cache_utils.py](cache_utils.py.md)` is reported as broken because it looks for `core_cache_cache_utils.py.md` instead of `cache_utils.py.md`

## Changes

- Commented out the scheduled cron trigger
- Kept manual and PR-based triggers functional
- Added comment explaining why it's disabled

## Next Steps

The workflow can be re-enabled once `scripts/check-docs-links.py` is fixed to correctly validate links.

Closes #173