### PR TITLE
docs: feature 'rxiv get-rxiv-preprint' command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,20 @@ rxiv check-installation
 **Get your first PDF quickly:**
 
 ```bash
-# Create manuscript 
+# Create manuscript
 rxiv init my-paper
 cd my-paper
+
+# Generate PDF
+rxiv pdf
+```
+
+**Or explore the complete example manuscript:**
+
+```bash
+# Clone the official example with one command
+rxiv get-rxiv-preprint
+cd manuscript-rxiv-maker/MANUSCRIPT
 
 # Generate PDF
 rxiv pdf
@@ -93,6 +104,12 @@ rxiv pdf
 - Comprehensive validation and error reporting
 
 ## 🌟 Example Manuscript
+
+> **💡 Get this complete example instantly:**
+> ```bash
+> rxiv get-rxiv-preprint
+> ```
+> This clones [manuscript-rxiv-maker](https://github.com/HenriquesLab/manuscript-rxiv-maker) with all features demonstrated.
 
 **Input Markdown:**
 ```markdown
@@ -172,7 +189,8 @@ The correlation coefficient was r = {{py:get correlation:.2f}} (p < 0.001).
 
 ```bash
 rxiv init my-paper          # Create new manuscript
-rxiv pdf                    # Generate PDF  
+rxiv get-rxiv-preprint     # Clone complete example manuscript
+rxiv pdf                    # Generate PDF
 rxiv validate              # Check manuscript quality
 rxiv arxiv                 # Prepare arXiv submission
 rxiv track-changes v1 v2   # Visual version comparison
@@ -184,7 +202,7 @@ rxiv track-changes v1 v2   # Visual version comparison
 
 - **💬 [GitHub Discussions](https://github.com/henriqueslab/rxiv-maker/discussions)** - Ask questions, share tips
 - **🐛 [Issues](https://github.com/henriqueslab/rxiv-maker/issues)** - Report bugs, request features  
-- **📚 [Example Manuscript](https://github.com/HenriquesLab/manuscript-rxiv-maker)** - Complete manuscript example
+- **📚 [Example Manuscript](https://github.com/HenriquesLab/manuscript-rxiv-maker)** - Clone instantly: `rxiv get-rxiv-preprint`
 - **🧪 [Google Colab](https://colab.research.google.com/github/HenriquesLab/rxiv-maker/blob/main/notebooks/rxiv_maker_colab.ipynb)** - Try without installing
 
 ## 🏗️ Contributing


### PR DESCRIPTION
## Summary
Add the rxiv get-rxiv-preprint command to multiple strategic locations in README to dramatically improve discoverability of the manuscript-rxiv-maker example repository.

## Problem
The rxiv get-rxiv-preprint command exists and provides excellent UX (one command clones the complete example), but it's not mentioned anywhere in the README. Users only see a GitHub link requiring manual cloning.

## Solution
Feature the command in 4 key locations throughout the README:

1. Quick Start Section - Alternative workflow after rxiv init
2. Example Manuscript Section - Prominent callout box
3. Essential Commands - Added to command list
4. Community Section - Enhanced existing mention

## Impact

### User Experience Improvements
- Multiple discovery points throughout README
- Reduced friction: one command vs manual GitHub cloning
- Better onboarding for new users
- Showcases modern CLI UX

### Statistics
- 21 insertions, 3 deletions
- 4 strategic locations in README
- 0 breaking changes

## Testing
- Verified all markdown formatting renders correctly
- Tested all code blocks are properly formatted
- Confirmed links work correctly
- Command functionality already exists and works

## Related
- Enhances discoverability of manuscript-rxiv-maker
- Complements existing Quick Start documentation
- Aligns with modern developer experience expectations