### PR TITLE
fix: exclude closing parenthesis from bare URL regex

### DIFF
--- a/src/rxiv_maker/converters/url_processor.py
+++ b/src/rxiv_maker/converters/url_processor.py
@@ -89,7 +89,7 @@ def _convert_bare_urls(text: MarkdownContent) -> LatexContent:
     text = re.sub(latex_href_pattern, protect_latex_command, text)
 
     # Now convert bare URLs
-    text = re.sub(r"https?://[^\s\}>\]]+", process_bare_url, text)
+    text = re.sub(r"https?://[^\s\}>\])]+", process_bare_url, text)
 
     # Restore protected LaTeX commands
     for i, cmd in enumerate(protected_commands):
@@ -129,7 +129,7 @@ def extract_urls_from_text(text: MarkdownContent) -> list[tuple[str, str]]:
         urls.append((link_text.strip(), url.strip()))
 
     # Find bare URLs
-    bare_urls = re.findall(r"https?://[^\s\}>\]]+", text)
+    bare_urls = re.findall(r"https?://[^\s\}>\])]+", text)
     for url in bare_urls:
         # For bare URLs, use the URL as both text and link
         urls.append((url, url))

--- a/tests/unit/test_md2tex.py
+++ b/tests/unit/test_md2tex.py
@@ -250,6 +250,28 @@ class TestURLEscaping:
         result = escape_url_for_latex(url)
         assert result == expected
 
+    def test_bare_url_in_parentheses(self):
+        """Test that bare URLs in parentheses don't include the closing parenthesis."""
+        from rxiv_maker.converters.url_processor import convert_links_to_latex
+
+        markdown = "(see https://example.com)"
+        result = convert_links_to_latex(markdown)
+        # The URL should be https://example.com, not https://example.com)
+        assert "\\url{https://example.com}" in result
+        assert "\\url{https://example.com)}" not in result
+        # The closing parenthesis should remain in the text
+        assert result == "(see \\url{https://example.com})"
+
+    def test_bare_url_in_parentheses_with_hash(self):
+        """Test that bare URLs with hash symbols in parentheses are handled correctly."""
+        from rxiv_maker.converters.url_processor import convert_links_to_latex
+
+        markdown = "(visit https://example.com/page#section for details)"
+        result = convert_links_to_latex(markdown)
+        # The URL should end at the closing parenthesis, not include it
+        assert "\\url{https://example.com/page\\#section}" in result
+        assert "\\url{https://example.com/page\\#section)}" not in result
+
 
 class TestListConversion:
     """Test markdown list conversion to LaTeX."""


### PR DESCRIPTION
## Summary
Fixes bug where bare URLs in parentheses incorrectly included the closing parenthesis as part of the URL.

## Problem
When text contained bare URLs in parentheses like `(see https://example.com)`, the regex pattern would capture `https://example.com)` including the closing parenthesis as part of the URL. This caused hyperlinks in the PDF output to include the unwanted `)` character.

## Solution
Updated the bare URL regex pattern in `url_processor.py` to exclude closing parentheses from the character class:
- Changed from: `https?://[^\s\}>\]]+`
- Changed to: `https?://[^\s\}>\])]+`

This was applied in two locations:
1. `_convert_bare_urls()` function (line 92)
2. `extract_urls_from_text()` function (line 132)

## Testing
- ✅ Added two new test cases for URLs in parentheses
- ✅ All URL-related tests pass
- ✅ Fast test suite passes (1174 tests)
- ⚠️ One pre-existing test failure unrelated to this change

## Test Plan
- [x] Unit tests added for URLs in parentheses
- [x] Unit tests added for URLs with hash symbols in parentheses
- [x] Verified the regex correctly excludes `)` from URLs
- [x] Confirmed existing URL tests still pass