### PR TITLE
fix: exclude Dependabot PRs from AI review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,14 @@ on:
 
 jobs:
   claude-review:
+    # Skip Dependabot PRs since they cannot access repository secrets
+    if: github.actor != 'dependabot[bot]'
     # Optional: Filter by PR author
     # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.actor != 'dependabot[bot]' &&
+    #   (github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR')
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -43,13 +43,14 @@ jobs:
           env | grep '^DEBUG_'
 
   dispatch:
-    # For PRs: only if not from a fork
+    # For PRs: only if not from a fork and not Dependabot (secrets not accessible)
     # For comments: only if user types @gemini-cli and is OWNER/MEMBER/COLLABORATOR
     # For issues: only on open/reopen
     if: |-
       (
         github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.fork == false
+        github.event.pull_request.head.repo.fork == false &&
+        github.actor != 'dependabot[bot]'
       ) || (
         github.event.sender.type == 'User' &&
         startsWith(github.event.comment.body || github.event.review.body || github.event.issue.body, '@gemini-cli') &&


### PR DESCRIPTION
## Summary

Fixes the Claude and Gemini AI review workflow failures on Dependabot PRs (like #194).

## Problem

Both AI review workflows were failing on Dependabot PRs with authentication errors:
- **Claude**: `ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required`
- **Gemini**: `Please set an Auth method... GEMINI_API_KEY... required`

**Root Cause:** Dependabot PRs cannot access repository secrets due to GitHub security restrictions. This is intentional to prevent malicious dependency updates from stealing secrets.

## Solution

Added conditions to both workflows to skip Dependabot PRs entirely:

### Changes
1. **`.github/workflows/claude-code-review.yml`**
   - Added: `if: github.actor != 'dependabot[bot]'`
   - Updated commented examples to show proper condition combining

2. **`.github/workflows/gemini-dispatch.yml`**
   - Added: `github.actor != 'dependabot[bot]'` to the dispatch condition
   - Maintains manual trigger functionality via `@gemini-cli`

## Testing

✅ YAML syntax validation passed
✅ Pre-commit hooks passed
✅ Logic preserves existing functionality for non-Dependabot PRs

## Impact

- ✅ **Fixes #194** and future Dependabot PR failures
- ✅ Reduces noise in CI/CD pipeline
- ✅ Dependabot PRs can still be reviewed via existing CI checks
- ✅ Manual AI review still possible via `@gemini-cli` or `@claude` comments for authorized users

## Notes

This is the recommended approach - Dependabot PRs are typically low-risk dependency updates that don't require AI code review. Security is maintained through existing dependency scanning and CI checks.
