### PR TITLE
fix: Correct import path for tips module

### DIFF
--- a/src/rxiv_maker/cli/framework/workflow_commands.py
+++ b/src/rxiv_maker/cli/framework/workflow_commands.py
@@ -239,7 +239,7 @@ class BuildCommand(BaseCommand):
     def _show_build_tips(self) -> None:
         """Show helpful tips after successful PDF build."""
         try:
-            from ..utils import get_build_success_tip
+            from ...utils.tips import get_build_success_tip
 
             # Always show tips - no configuration needed
             tip = get_build_success_tip(frequency="always")


### PR DESCRIPTION
## Problem
ModuleNotFoundError occurs when showing build tips after PDF generation:
```
ModuleNotFoundError: No module named 'rxiv_maker.cli.utils'
```

## Root Cause
The import in `workflow_commands.py` was using:
```python
from ..utils import get_build_success_tip
```

But `rxiv_maker.cli.utils` doesn't exist - the tips module is in `rxiv_maker.utils.tips`.

## Solution
Changed import to:
```python
from ...utils.tips import get_build_success_tip
```

## Testing
- ✅ Tested PDF build with tips display
- ✅ Tips now show correctly after successful build
- ✅ No import errors

## Type
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] Breaking change

This is a hotfix for v1.9.0 release.