### PR TITLE
chore: Release v1.9.1 - Hotfix for import error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.9.1] - 2025-11-16
+
+### Fixed
+- **Import Error**: Fixed `ModuleNotFoundError` in workflow commands when importing tips module
+  - Corrected import path from `from ..utils import` to `from ...utils.tips import` in `workflow_commands.py:242`
+  - Resolves error: "No module named 'rxiv_maker.cli.utils'"
+  - This hotfix ensures build success tips display correctly
+
 ## [v1.9.0] - 2025-11-16
 
 ### Added

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,7 +1,7 @@
 """Version information for rxiv-maker."""
 
-__version__ = "1.9.0"
-__version_tuple__ = (1, 9, 0)
+__version__ = "1.9.1"
+__version_tuple__ = (1, 9, 1)
 
 # Note: Docker images v1.8+ use mermaid.ink API for diagram processing
 # This improves cross-platform compatibility and performance


### PR DESCRIPTION
## Summary
Patch release v1.9.1 to fix critical import error in v1.9.0.

## Changes
- **Fixed**: `ModuleNotFoundError` when importing tips module in workflow commands
- Corrected import path from `from ..utils import` to `from ...utils.tips import`
- Resolves error: "No module named 'rxiv_maker.cli.utils'"

## Testing
- [x] All unit tests pass
- [x] Import error resolved
- [x] Tips display correctly after build

## Related Issues
- Fixes #206 (merged hotfix)
- Hotfix for issue discovered after v1.9.0 release

## Release Notes
See CHANGELOG.md for full details.