### PR TITLE
feat: supplementary videos (svideo) with linked, numbered captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-06-01
+
 ### Added
 - Supplementary videos. A still image followed by a
   `{#svideo:id url="..."} **Title.** Description` directive renders as a
   non-floating, independently numbered "Supplementary Video N" caption with a
-  "Watch video" hyperlink, and can be cross-referenced from anywhere with
-  `@svideo:id` (rendered as "Supplementary Video N"). Supported in both PDF and
-  DOCX output.
+  "Watch video" hyperlink. The still image itself is also clickable and links
+  to the video. Cross-reference from anywhere with `@svideo:id` (rendered as
+  "Supplementary Video N"). Supported in both PDF and DOCX output.
 
 ## [1.19.2] - 2026-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Supplementary videos. A still image followed by a
+  `{#svideo:id url="..."} **Title.** Description` directive renders as a
+  non-floating, independently numbered "Supplementary Video N" caption with a
+  "Watch video" hyperlink, and can be cross-referenced from anywhere with
+  `@svideo:id` (rendered as "Supplementary Video N"). Supported in both PDF and
+  DOCX output.
+
 ## [1.19.2] - 2026-02-05
 
 ### Fixed

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.19.2"
+__version__ = "1.20.0"

--- a/src/rxiv_maker/converters/citation_processor.py
+++ b/src/rxiv_maker/converters/citation_processor.py
@@ -57,7 +57,7 @@ def convert_citations_to_latex(text: MarkdownContent, citation_style: str = "num
     # Handle single citations like @citation_key (but not figure/equation references)
     # Allow alphanumeric, underscore, and hyphen in citation keys
     # Exclude figure and equation references by not matching @fig: or @eq: patterns
-    text = re.sub(r"@(?!fig:|eq:)([a-zA-Z0-9_-]+)", rf"\\{inline_cmd}{{\1}}", text)
+    text = re.sub(r"@(?!fig:|eq:|svideo:)([a-zA-Z0-9_-]+)", rf"\\{inline_cmd}{{\1}}", text)
 
     # Restore protected email patterns
     for i, pattern in enumerate(email_patterns):

--- a/src/rxiv_maker/converters/md2tex.py
+++ b/src/rxiv_maker/converters/md2tex.py
@@ -32,6 +32,11 @@ from .supplementary_note_processor import (
     process_supplementary_notes,
     restore_supplementary_note_placeholders,
 )
+from .supplementary_video_processor import (
+    process_supplementary_video_references,
+    process_supplementary_videos,
+    restore_supplementary_video_placeholders,
+)
 from .table_processor import convert_table_references_to_latex, convert_tables_to_latex
 from .text_formatters import (
     convert_subscript_superscript_to_latex,
@@ -163,6 +168,11 @@ def convert_markdown_to_latex(
         citation_style,
     )
 
+    # Process supplementary videos BEFORE figures so the still image is not
+    # turned into a numbered figure float (only for supplementary content)
+    if is_supplementary:
+        content = process_supplementary_videos(content)
+
     # Convert figures BEFORE headers to avoid conflicts
     content = convert_figures_to_latex(content, is_supplementary)
 
@@ -191,6 +201,10 @@ def convert_markdown_to_latex(
     # (for both main and supplementary content)
     content = process_supplementary_note_references(content)
 
+    # Process supplementary video references BEFORE citations
+    # (for both main and supplementary content)
+    content = process_supplementary_video_references(content)
+
     # Convert citations with table protection
     content = process_citations_outside_tables(content, protected_markdown_tables, citation_style)
 
@@ -200,6 +214,10 @@ def convert_markdown_to_latex(
     # Restore supplementary note placeholders after text formatting
     if is_supplementary:
         content = restore_supplementary_note_placeholders(content)
+
+    # Restore supplementary video placeholders after text formatting
+    if is_supplementary:
+        content = restore_supplementary_video_placeholders(content)
 
     # Convert markdown links to LaTeX URLs
     content = convert_links_to_latex(content)

--- a/src/rxiv_maker/converters/supplementary_video_processor.py
+++ b/src/rxiv_maker/converters/supplementary_video_processor.py
@@ -42,17 +42,18 @@ def _build_latex(image_path: str, svideo_id: str, attrs: str, title: str) -> str
     width_match = _WIDTH_ATTR.search(attrs)
     width = width_match.group(1) if width_match else "0.9\\linewidth"
 
+    url = url_match.group(1) if url_match else None
+
     parts: list[str] = []
     if image_path:
-        parts.append(
-            "\\begin{center}\n"
-            f"\\includegraphics[width={width}]{{{image_path.strip()}}}\n"
-            "\\end{center}"
-        )
+        image = f"\\includegraphics[width={width}]{{{image_path.strip()}}}"
+        # Make the still itself a clickable link to the video when a URL is given.
+        if url:
+            image = f"\\href{{{url}}}{{{image}}}"
+        parts.append("\\begin{center}\n" + image + "\n\\end{center}")
 
     caption = f"\\suppvideo{{{title.strip()}}}\\label{{svideo:{svideo_id}}}"
-    if url_match:
-        url = url_match.group(1)
+    if url:
         caption += f" (\\href{{{url}}}{{$\\blacktriangleright$~Watch video}})"
     parts.append(caption)
 

--- a/src/rxiv_maker/converters/supplementary_video_processor.py
+++ b/src/rxiv_maker/converters/supplementary_video_processor.py
@@ -1,0 +1,119 @@
+"""Supplementary video processing for markdown to LaTeX conversion.
+
+This module handles the conversion of supplementary video blocks. A
+supplementary video is written as an (optional) still image followed by a
+caption directive carrying a link to the video::
+
+    ![alt](FIGURES/SVideo1.png)
+    {#svideo:workflow url="https://youtu.be/XXXX"} **Title.** Description.
+
+It is rendered as a non-floating, centred still image (so it is *not*
+auto-numbered as a supplementary figure), followed by an automatically
+numbered "Supplementary Video N. Title." caption, a "Watch video" hyperlink to
+the URL, and the description. Videos are numbered independently from figures,
+tables and notes, and can be cross-referenced from anywhere in the document
+with ``@svideo:id`` (rendered as "Supplementary Video N").
+"""
+
+import re
+
+from .types import LatexContent
+
+# Block: optional image line, then `{#svideo:id ...attrs} **Title**`.
+# Only the directive (and the optional image) is captured; the description that
+# follows **Title** is left in place so it is formatted normally downstream.
+_SVIDEO_PATTERN = re.compile(
+    r"(?:!\[[^\]]*\]\(([^)]+)\)[ \t]*\r?\n[ \t]*)?"  # group 1: optional image path
+    r"\{#svideo:([\w-]+)([^}]*)\}[ \t]*"  # group 2: id, group 3: raw attrs
+    r"\*\*([^*]+)\*\*",  # group 4: bold title
+    re.MULTILINE,
+)
+
+_URL_ATTR = re.compile(r"""url\s*=\s*["']?([^"'\s}]+)""")
+_WIDTH_ATTR = re.compile(r"""width\s*=\s*["']?([^"'\s}]+)""")
+
+# Module-level store for protected replacements (mirrors the snote processor).
+_svideo_replacements: dict[str, str] = {}
+
+
+def _build_latex(image_path: str, svideo_id: str, attrs: str, title: str) -> str:
+    """Build the LaTeX for one supplementary video block."""
+    url_match = _URL_ATTR.search(attrs)
+    width_match = _WIDTH_ATTR.search(attrs)
+    width = width_match.group(1) if width_match else "0.9\\linewidth"
+
+    parts: list[str] = []
+    if image_path:
+        parts.append(
+            "\\begin{center}\n"
+            f"\\includegraphics[width={width}]{{{image_path.strip()}}}\n"
+            "\\end{center}"
+        )
+
+    caption = f"\\suppvideo{{{title.strip()}}}\\label{{svideo:{svideo_id}}}"
+    if url_match:
+        url = url_match.group(1)
+        caption += f" (\\href{{{url}}}{{$\\blacktriangleright$~Watch video}})"
+    parts.append(caption)
+
+    return "\n".join(parts)
+
+
+def process_supplementary_videos(content: LatexContent) -> LatexContent:
+    """Convert supplementary video blocks to protected LaTeX placeholders.
+
+    Must run BEFORE figure conversion so the still image is not turned into a
+    numbered figure float. The replacement is stored behind an inert placeholder
+    and restored after text formatting via
+    :func:`restore_supplementary_video_placeholders`.
+
+    Args:
+        content: The markdown content to process.
+
+    Returns:
+        Content with supplementary video blocks replaced by placeholders.
+    """
+    global _svideo_replacements
+    _svideo_replacements = {}
+
+    counter = 0
+
+    def _replace(match: re.Match) -> str:
+        nonlocal counter
+        image_path = match.group(1) or ""
+        svideo_id = match.group(2).strip()
+        attrs = match.group(3) or ""
+        title = match.group(4)
+
+        placeholder = f"XXSVIDEOPROTECTEDXX{counter}XXENDXX"
+        _svideo_replacements[placeholder] = _build_latex(image_path, svideo_id, attrs, title)
+        counter += 1
+        return placeholder
+
+    return _SVIDEO_PATTERN.sub(_replace, content)
+
+
+def restore_supplementary_video_placeholders(content: LatexContent) -> LatexContent:
+    """Restore supplementary video placeholders with their LaTeX.
+
+    Should be called after all text formatting is complete.
+    """
+    global _svideo_replacements
+    for placeholder, latex in _svideo_replacements.items():
+        content = content.replace(placeholder, latex)
+    _svideo_replacements = {}
+    return content
+
+
+def process_supplementary_video_references(content: LatexContent) -> LatexContent:
+    r"""Convert ``@svideo:id`` references to "Supplementary Video \\ref{...}".
+
+    Run before citation processing so the reference is not mistaken for a
+    citation key.
+    """
+
+    def _replace(match: re.Match) -> str:
+        label = match.group(1)
+        return f"Supplementary Video~\\ref{{svideo:{label}}}"
+
+    return re.sub(r"@svideo:([a-zA-Z0-9_-]+)", _replace, content)

--- a/src/rxiv_maker/exporters/docx_citation_mapper.py
+++ b/src/rxiv_maker/exporters/docx_citation_mapper.py
@@ -127,7 +127,7 @@ class CitationMapper:
             return match.group(0)
 
         text = re.sub(
-            r"@(?!fig:|eq:|tbl:|table:|sfig:|stable:|snote:)([a-zA-Z0-9_-]+)",
+            r"@(?!fig:|eq:|tbl:|table:|sfig:|stable:|snote:|svideo:)([a-zA-Z0-9_-]+)",
             replace_single,
             text,
         )

--- a/src/rxiv_maker/exporters/docx_exporter.py
+++ b/src/rxiv_maker/exporters/docx_exporter.py
@@ -193,6 +193,39 @@ class DocxExporter:
 
         logger.debug(f"Mapped {len(snote_map)} supplementary note labels to numbers")
 
+        # Find all supplementary videos and create mapping (looking for {#svideo:label} tags)
+        content_to_scan_for_svideos = si_content_for_mapping if si_content_for_mapping else markdown_with_numbers
+        svideo_map = label_extractor.extract_supplementary_video_labels(content_to_scan_for_svideos)
+
+        # Number each video definition inline and render its link, e.g.
+        # {#svideo:x url="..."} **Title.** -> **Supplementary Video N. Title.** (Watch the video: ...)
+        def _make_svideo_def_replacer(num):
+            def _replace(match):
+                attrs = match.group(1) or ""
+                title = match.group(2).strip()
+                url_match = re.search(r"""url\s*=\s*["']?([^"'\s}]+)""", attrs)
+                link = f" (Watch the video: {url_match.group(1)})" if url_match else ""
+                return f"**Supplementary Video {num}. {title}**{link}"
+
+            return _replace
+
+        for label, num in svideo_map.items():
+            markdown_with_numbers = re.sub(
+                rf"\{{#svideo:{label}([^}}]*)\}}\s*\*\*([^*]+)\*\*",
+                _make_svideo_def_replacer(num),
+                markdown_with_numbers,
+            )
+
+        # Replace @svideo:label with "Supplementary Video X" in text
+        for label, num in svideo_map.items():
+            markdown_with_numbers = re.sub(
+                rf"@svideo:{label}\b",
+                f"<<XREF:svideo>>Supplementary Video {num}<</XREF>>",
+                markdown_with_numbers,
+            )
+
+        logger.debug(f"Mapped {len(svideo_map)} supplementary video labels to numbers")
+
         # Find all equations and create mapping (looking for {#eq:label} tags)
         equation_map = label_extractor.extract_equation_labels(markdown_with_numbers)
 
@@ -211,7 +244,9 @@ class DocxExporter:
         # Step 5.6: Remove label markers now that mapping is complete
         # These metadata markers should not appear in the final output
         # NOTE: Keep fig/sfig/stable/table labels - they're needed by content processor and removed during caption parsing
-        markdown_with_numbers = re.sub(r"^\{#(?:snote|eq):[^}]+\}\s*", "", markdown_with_numbers, flags=re.MULTILINE)
+        markdown_with_numbers = re.sub(
+            r"^\{#(?:snote|eq|svideo):[^}]+\}\s*", "", markdown_with_numbers, flags=re.MULTILINE
+        )
 
         # Step 6: Convert content to DOCX structure
         doc_structure = self.content_processor.parse(markdown_with_numbers, citation_map)

--- a/src/rxiv_maker/exporters/docx_writer.py
+++ b/src/rxiv_maker/exporters/docx_writer.py
@@ -34,6 +34,7 @@ class DocxWriter:
         "table": WD_COLOR_INDEX.BLUE,  # Main tables
         "eq": WD_COLOR_INDEX.PINK,  # Equations (pink - lighter than violet, easier to read)
         "snote": WD_COLOR_INDEX.TURQUOISE,  # Supplementary notes (turquoise - lighter cyan)
+        "svideo": WD_COLOR_INDEX.TURQUOISE,  # Supplementary videos (turquoise - lighter cyan)
         "cite": WD_COLOR_INDEX.YELLOW,  # Citations (yellow)
     }
 

--- a/src/rxiv_maker/utils/label_extractor.py
+++ b/src/rxiv_maker/utils/label_extractor.py
@@ -123,6 +123,21 @@ class LabelExtractor:
         return {label: i + 1 for i, label in enumerate(labels)}
 
     @staticmethod
+    def extract_supplementary_video_labels(content: str) -> Dict[str, int]:
+        r"""Extract supplementary video labels and create number mapping.
+
+        Finds patterns like: {#svideo:label ...attrs}
+
+        Args:
+            content: Markdown content to scan
+
+        Returns:
+            Dict mapping label names to sequential numbers
+        """
+        labels = re.findall(r"\{#svideo:([\w-]+)", content)
+        return {label: i + 1 for i, label in enumerate(labels)}
+
+    @staticmethod
     def extract_equation_labels(content: str) -> Dict[str, int]:
         r"""Extract equation labels and create number mapping.
 

--- a/src/rxiv_maker/validators/citation_validator.py
+++ b/src/rxiv_maker/validators/citation_validator.py
@@ -28,7 +28,9 @@ class CitationValidator(BaseValidator):
     # Citation patterns from the codebase analysis
     CITATION_PATTERNS = {
         "bracketed_multiple": re.compile(r"\[(@[^]]+)\]"),  # [@citation1;@citation2]
-        "single_citation": re.compile(r"@(?!fig:|eq:|table:|tbl:|sfig:|stable:|snote:)([a-zA-Z0-9_-]+)"),  # @key
+        "single_citation": re.compile(
+            r"@(?!fig:|eq:|table:|tbl:|sfig:|stable:|snote:|svideo:)([a-zA-Z0-9_-]+)"
+        ),  # @key
         "protected_citation": re.compile(r"XXPROTECTEDTABLEXX\d+XXPROTECTEDTABLEXX"),  # Skip protected content
     }
 

--- a/src/rxiv_maker/validators/reference_validator.py
+++ b/src/rxiv_maker/validators/reference_validator.py
@@ -18,6 +18,7 @@ class ReferenceValidator(BaseValidator):
         "supplementary_table_ref": re.compile(r"@stable:([a-zA-Z0-9_-]+)"),
         "equation_ref": re.compile(r"@eq:([a-zA-Z0-9_-]+)"),
         "supplementary_note_ref": re.compile(r"@snote:([a-zA-Z0-9_-]+)"),
+        "supplementary_video_ref": re.compile(r"@svideo:([a-zA-Z0-9_-]+)"),
     }
 
     # Label definition patterns
@@ -28,6 +29,7 @@ class ReferenceValidator(BaseValidator):
         "supplementary_table_label": re.compile(r"\{#stable:([a-zA-Z0-9_:-]+)([^}]*)\}"),
         "equation_label": re.compile(r"\$\$.*?\$\$\s*\{[^}]*#eq:([a-zA-Z0-9_:-]+)[^}]*\}"),
         "supplementary_note_label": re.compile(r"\{#snote:([a-zA-Z0-9_:-]+)\}"),
+        "supplementary_video_label": re.compile(r"\{#svideo:([a-zA-Z0-9_:-]+)([^}]*)\}"),
     }
 
     def __init__(self, manuscript_path: str):
@@ -44,6 +46,7 @@ class ReferenceValidator(BaseValidator):
             "stable": {},
             "eq": {},
             "snote": {},
+            "svideo": {},
         }
         self.referenced_labels: dict[str, list[dict[str, Any]]] = {
             "fig": [],
@@ -52,6 +55,7 @@ class ReferenceValidator(BaseValidator):
             "stable": [],
             "eq": [],
             "snote": [],
+            "svideo": [],
         }
 
     def validate(self) -> ValidationResult:
@@ -278,6 +282,7 @@ class ReferenceValidator(BaseValidator):
             "supplementary_table_label": "stable",
             "equation_label": "eq",
             "supplementary_note_label": "snote",
+            "supplementary_video_label": "svideo",
         }
         return mapping.get(label_type, "unknown")
 
@@ -290,6 +295,7 @@ class ReferenceValidator(BaseValidator):
             "supplementary_table_ref": "stable",
             "equation_ref": "eq",
             "supplementary_note_ref": "snote",
+            "supplementary_video_ref": "svideo",
         }
         return mapping.get(pattern_name, "unknown")
 

--- a/src/tex/style/rxiv_maker_style.cls
+++ b/src/tex/style/rxiv_maker_style.cls
@@ -130,6 +130,15 @@
   \subsection*{\thesubsection: #1}%
 }
 
+%% Custom command for supplementary videos (numbered independently from figures and notes)
+%% Renders a bold "Supplementary Video N. <title>" caption; \refstepcounter lets a
+%% following \label{svideo:id} resolve to the video number for @svideo cross-references.
+\newcounter{svideo}
+\newcommand{\suppvideo}[1]{%
+  \refstepcounter{svideo}%
+  \par\noindent\textbf{Supplementary Video \thesvideo. #1}%
+}
+
 %% Unified supplementary float environments
 % Supplementary figures counter and environments
 \newcounter{sfigure}

--- a/tests/unit/test_supplementary_video_processor.py
+++ b/tests/unit/test_supplementary_video_processor.py
@@ -22,6 +22,10 @@ class TestSupplementaryVideoDefinition:
         )
         out = _process_and_restore(content)
         assert "\\includegraphics[width=0.9\\linewidth]{FIGURES/SVideo1.png}" in out
+        # The still image itself is a clickable link to the video.
+        assert (
+            "\\href{https://youtu.be/ABC}{\\includegraphics[width=0.9\\linewidth]{FIGURES/SVideo1.png}}" in out
+        )
         assert "\\begin{center}" in out and "\\end{center}" in out
         assert "\\suppvideo{Complete workflow.}" in out
         assert "\\label{svideo:workflow}" in out

--- a/tests/unit/test_supplementary_video_processor.py
+++ b/tests/unit/test_supplementary_video_processor.py
@@ -1,0 +1,80 @@
+"""Unit tests for the supplementary video processor."""
+
+from rxiv_maker.converters.supplementary_video_processor import (
+    process_supplementary_video_references,
+    process_supplementary_videos,
+    restore_supplementary_video_placeholders,
+)
+
+
+def _process_and_restore(content: str) -> str:
+    """Run the full define -> placeholder -> restore round trip."""
+    processed = process_supplementary_videos(content)
+    return restore_supplementary_video_placeholders(processed)
+
+
+class TestSupplementaryVideoDefinition:
+    def test_full_block_with_image_and_url(self):
+        content = (
+            "![still](FIGURES/SVideo1.png)\n"
+            '{#svideo:workflow url="https://youtu.be/ABC"} '
+            "**Complete workflow.** Example use of VLab4Mic."
+        )
+        out = _process_and_restore(content)
+        assert "\\includegraphics[width=0.9\\linewidth]{FIGURES/SVideo1.png}" in out
+        assert "\\begin{center}" in out and "\\end{center}" in out
+        assert "\\suppvideo{Complete workflow.}" in out
+        assert "\\label{svideo:workflow}" in out
+        assert "\\href{https://youtu.be/ABC}{$\\blacktriangleright$~Watch video}" in out
+        # The description after **Title** is left in place for normal formatting.
+        assert "Example use of VLab4Mic." in out
+        # The raw directive must be gone.
+        assert "{#svideo:" not in out
+
+    def test_block_without_image(self):
+        content = '{#svideo:demo url="https://youtu.be/XYZ"} **Demo title.** Body text.'
+        out = _process_and_restore(content)
+        assert "\\includegraphics" not in out
+        assert "\\suppvideo{Demo title.}" in out
+        assert "\\label{svideo:demo}" in out
+        assert "Watch video" in out
+
+    def test_block_without_url(self):
+        content = "![s](FIGURES/v.png)\n{#svideo:noumdl} **No link.** Body."
+        out = _process_and_restore(content)
+        assert "\\suppvideo{No link.}" in out
+        assert "Watch video" not in out  # no link rendered when url is absent
+        assert "\\href" not in out
+
+    def test_custom_width(self):
+        content = "![s](FIGURES/v.png)\n" + r'{#svideo:wide url="u" width="0.5\linewidth"} **T.** d.'
+        out = _process_and_restore(content)
+        assert r"width=0.5\linewidth" in out
+
+    def test_two_videos_get_distinct_labels(self):
+        content = (
+            "![a](FIGURES/v1.png)\n{#svideo:one url=\"u1\"} **First.** d1.\n\n"
+            "![b](FIGURES/v2.png)\n{#svideo:two url=\"u2\"} **Second.** d2.\n"
+        )
+        out = _process_and_restore(content)
+        assert "\\label{svideo:one}" in out
+        assert "\\label{svideo:two}" in out
+        assert out.index("svideo:one") < out.index("svideo:two")
+
+    def test_no_videos_is_noop(self):
+        content = "Just some text with @snote:foo and a ![fig](x.pdf)."
+        assert _process_and_restore(content) == content
+
+
+class TestSupplementaryVideoReferences:
+    def test_callout_renders_with_prefix(self):
+        out = process_supplementary_video_references("See (@svideo:workflow) for details.")
+        assert out == "See (Supplementary Video~\\ref{svideo:workflow}) for details."
+
+    def test_multiple_references(self):
+        out = process_supplementary_video_references("@svideo:one and @svideo:two")
+        assert out == "Supplementary Video~\\ref{svideo:one} and Supplementary Video~\\ref{svideo:two}"
+
+    def test_non_svideo_at_is_untouched(self):
+        text = "Email a@b and cite @key and @snote:n."
+        assert process_supplementary_video_references(text) == text


### PR DESCRIPTION
Adds a first-class **supplementary video** element, for manuscripts that ship walkthrough videos.

## Usage
```markdown
![still](FIGURES/SVideo1.png)
{#svideo:workflow url="https://youtu.be/XXXX"} **Complete workflow.** Example use of ...
```
Renders as a non-floating, independently numbered caption with a hyperlink:
> **Supplementary Video 1. Complete workflow.** (▶ Watch video) Example use of ...

The still image is intentionally **not** turned into a figure float (so it is not mis-numbered as a Supplementary Figure). Cross-reference anywhere with `@svideo:workflow` → **"Supplementary Video 1"**. Numbered independently from figures, tables and notes.

## Implementation (mirrors the supplementary-note path)
- `converters/supplementary_video_processor.py` — define/restore + reference passes
- `converters/md2tex.py` — wired **before** figure conversion (still ≠ float) and alongside the snote passes
- `tex/style/rxiv_maker_style.cls` — `\suppvideo` command + independent `svideo` counter
- citation + reference **validators** and citation **processors** — treat `@svideo:` as a cross-reference, not a citation
- **DOCX** export — number definitions, render the link, map `@svideo:` refs

## Tests / verification
- New unit tests (9 passing). No regressions in the citation/reference/supplementary suite (146 passing; the one `test_build_process_resolves_citations` failure is pre-existing on `main`).
- Verified end-to-end on a real manuscript: **PDF** renders the numbered caption + still + ▶ Watch video hyperlink and `@svideo` refs resolve (0 unresolved); **DOCX** shows the captions/refs and "Watch the video" links with no leftover markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)