### PR TITLE
fix(biorxiv): emit all affiliations and support inline-affiliation configs

### DIFF
--- a/src/rxiv_maker/engines/operations/prepare_biorxiv.py
+++ b/src/rxiv_maker/engines/operations/prepare_biorxiv.py
@@ -191,11 +191,21 @@ def format_author_row(author_data: dict, affiliation_map: dict) -> list[str]:
     # Email (decoded from email64)
     email = author_data.get("email", "")
 
-    # Institution (first affiliation's full_name) - encode HTML entities for bioRxiv
-    institution = ""
-    affiliations = author_data.get("affiliations", [])
-    if affiliations and affiliations[0] in affiliation_map:
-        institution = encode_html_entities(affiliation_map[affiliations[0]].get("full_name", ""))
+    # Institution(s) - encode HTML entities for bioRxiv.
+    # Resolve every affiliation: when the entry is a registered shortname use its
+    # full_name, otherwise treat the entry as a literal full affiliation string
+    # (inline-affiliation configs that omit the top-level affiliations map).
+    # bioRxiv exposes a single Institution column, so multiple affiliations are
+    # joined with "; " to preserve all of them.
+    resolved_affiliations = []
+    for affiliation in author_data.get("affiliations", []):
+        if affiliation in affiliation_map:
+            full_name = affiliation_map[affiliation].get("full_name", "") or affiliation
+        else:
+            full_name = affiliation
+        if full_name:
+            resolved_affiliations.append(full_name)
+    institution = encode_html_entities("; ".join(resolved_affiliations))
 
     # Parse name into components and encode HTML entities for bioRxiv
     name_str = author_data.get("name", "")

--- a/tests/unit/test_prepare_biorxiv.py
+++ b/tests/unit/test_prepare_biorxiv.py
@@ -157,8 +157,8 @@ class TestFormatAuthorRow:
         row = format_author_row(author_data, affiliation_map)
         assert row[1] == ""  # Institution should be empty string
 
-    def test_multiple_affiliations_uses_first(self):
-        """Test that only first affiliation is used."""
+    def test_multiple_affiliations_joined(self):
+        """All affiliations are joined with '; ' into bioRxiv's single Institution column."""
         author_data = {
             "name": "John Smith",
             "email": "",
@@ -171,7 +171,27 @@ class TestFormatAuthorRow:
         }
 
         row = format_author_row(author_data, affiliation_map)
-        assert row[1] == "Primary University"  # Only first affiliation
+        assert row[1] == "Primary University; Secondary Institute"
+
+    def test_inline_affiliation_strings(self):
+        """Affiliations absent from the shortname map are used as literal full names.
+
+        Inline-affiliation configs list full affiliation strings directly under each
+        author and omit the top-level affiliations map.
+        """
+        author_data = {
+            "name": "John Smith",
+            "email": "",
+            "affiliations": [
+                "Example University, City, Country",
+                "Second Institute, City, Country",
+            ],
+            "corresponding_author": False,
+        }
+        affiliation_map = {}
+
+        row = format_author_row(author_data, affiliation_map)
+        assert row[1] == "Example University, City, Country; Second Institute, City, Country"
 
 
 class TestGenerateBiorxivAuthorTsv:


### PR DESCRIPTION
## Problem

The bioRxiv author-template (`rxiv biorxiv`) TSV generator (`format_author_row`) had two issues:

1. **Only the first affiliation was emitted** (`affiliations[0]`), so authors with multiple affiliations silently lost all but the first.
2. **Affiliations were only resolved via the top-level `affiliations:` shortname→`full_name` map.** Manuscripts that list full affiliation strings *inline* under each author (and omit the top-level map) produced an **empty Institution column**, which bioRxiv rejects (Institution is a required import field).

## Fix

`format_author_row` now resolves *every* affiliation — shortname → `full_name` when present in the map, otherwise the literal string — and joins them with `"; "` into bioRxiv's single Institution column.

## Tests

- Updated `test_multiple_affiliations_uses_first` → `test_multiple_affiliations_joined` (asserts joining).
- Added `test_inline_affiliation_strings` (inline-affiliation config, empty map).
- Full module suite green (24 passed, 2 skipped); ruff clean.

Verified end-to-end: `rxiv biorxiv` on a real manuscript with multi-affiliation authors now produces a TSV whose header is byte-identical to bioRxiv's official template, with all affiliations preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)