### PR TITLE
docs: CHANGELOG entry for 1.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.2] - 2026-06-02
+
+### Fixed
+- bioRxiv author template (`rxiv biorxiv`): the Institution column now includes
+  *all* of an author's affiliations (joined with `"; "`) instead of only the
+  first, and resolves inline full-name affiliations when no top-level
+  `affiliations:` shortname map is present. Previously, configs that list full
+  affiliation strings inline produced an empty Institution column, which bioRxiv
+  rejects on import. (#303)
+
 ## [1.20.1] - 2026-06-01
 
 ### Changed


### PR DESCRIPTION
Adds the 1.20.2 CHANGELOG entry for the bioRxiv author-TSV affiliations fix (#303).

🤖 Generated with [Claude Code](https://claude.com/claude-code)