### PR TITLE
chore: bump version to 1.20.2

### DIFF
--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.20.1"
+__version__ = "1.20.2"


### PR DESCRIPTION
Bumps `__version__.py` to 1.20.2 for the patch release (bioRxiv TSV affiliations fix, #303).

🤖 Generated with [Claude Code](https://claude.com/claude-code)