### PR TITLE
adding --split-si functionality to rxiv-maker

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -89,6 +89,7 @@ rxiv pdf
 - `--force-figures` - Regenerate all figures regardless of cache
 - `--skip-validation` - Skip manuscript validation (faster)
 - `--track-changes <tag>` - Track changes against specified git tag
+- `--split-si` - Split the final PDF into `__main.pdf` and `__si.pdf`
 - `--verbose` - Detailed output for debugging
 - `--quiet` - Minimal output
 - `--debug` - Enable debug output
@@ -262,6 +263,32 @@ rxiv clean --figures-only
 # Clean only arXiv files
 rxiv clean --arxiv-only
 ```
+
+---
+
+### `rxiv docx` - Export Word Documents
+
+**Purpose**: Export manuscript content to DOCX for collaborative review.
+
+```bash
+# Export one DOCX containing main text and SI
+rxiv docx
+
+# Split main text and SI into separate DOCX files
+rxiv docx --split-si
+
+# Export main text as DOCX and SI as PDF
+rxiv docx --split-si-pdf
+```
+
+**Options**:
+- `[manuscript_path]` - Path to manuscript directory (default: current)
+- `--resolve-dois` - Attempt to resolve missing DOI metadata
+- `--no-footnotes` - Disable DOI footnotes/references section
+- `--split-si` - Output `__main.docx` and `__si.docx`
+- `--split-si-pdf` - Output `__main.docx` and `__si.pdf`
+- `--verbose` - Detailed output for debugging
+- `--quiet` - Minimal output
 
 ---
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -753,6 +753,12 @@ rxiv docx
 
 # Export with DOI resolution (citation update)
 rxiv docx --resolve-dois
+
+# Export main text and supplementary information as separate DOCX files
+rxiv docx --split-si
+
+# Export main text as DOCX and supplementary information as PDF
+rxiv docx --split-si-pdf
 ```
 
 **Features:**

--- a/src/rxiv_maker/cli/commands/docx.py
+++ b/src/rxiv_maker/cli/commands/docx.py
@@ -3,6 +3,7 @@
 import platform
 import shutil
 import subprocess
+from pathlib import Path
 
 import rich_click as click
 from rich.console import Console
@@ -10,6 +11,7 @@ from rich.console import Console
 from ...core.logging_config import get_logger
 from ...core.managers.dependency_manager import DependencyStatus, get_dependency_manager
 from ...exporters.docx_exporter import DocxExporter
+from ...utils.unicode_safe import get_safe_icon
 
 logger = get_logger()
 console = Console()
@@ -81,6 +83,57 @@ def _check_and_offer_poppler_installation(console: Console, quiet: bool, verbose
             console.print()
 
 
+def _export_docx_file(
+    manuscript_path: str,
+    resolve_dois: bool,
+    no_footnotes: bool,
+    content_mode: str,
+    output_suffix: str | None,
+) -> Path:
+    """Export one DOCX artifact and return its path."""
+    exporter = DocxExporter(
+        manuscript_path=manuscript_path,
+        resolve_dois=resolve_dois,
+        include_footnotes=not no_footnotes,
+        content_mode=content_mode,
+        output_suffix=output_suffix,
+    )
+    return exporter.export()
+
+
+def _build_and_export_si_pdf(manuscript_path: str, quiet: bool, verbose: bool) -> Path:
+    """Build the manuscript PDF, split SI, and copy the SI PDF beside the manuscript."""
+    from ...engines.operations.build_manager import BuildManager
+    from ...processors.yaml_processor import extract_yaml_metadata
+    from ...utils.file_helpers import find_manuscript_md
+    from ...utils.pdf_splitter import split_pdf
+    from ...utils.pdf_utils import get_custom_pdf_filename
+
+    if not quiet:
+        console.print(f"[cyan]{get_safe_icon('📄', '[PDF]')} Building PDF for SI split...[/cyan]")
+
+    build_manager = BuildManager(
+        manuscript_path=manuscript_path,
+        output_dir="output",
+        verbose=verbose,
+        quiet=quiet,
+    )
+    if not build_manager.build():
+        raise RuntimeError("PDF build failed")
+
+    _, si_path = split_pdf(build_manager.output_pdf)
+    if si_path is None:
+        raise RuntimeError("Could not split PDF: SI section marker not found")
+
+    manuscript_dir = Path(manuscript_path)
+    manuscript_md = find_manuscript_md(str(manuscript_dir))
+    yaml_metadata = extract_yaml_metadata(str(manuscript_md))
+    base_name = get_custom_pdf_filename(yaml_metadata).replace(".pdf", "")
+    final_si_path = manuscript_dir / f"{base_name}__si.pdf"
+    shutil.copy2(si_path, final_si_path)
+    return final_si_path
+
+
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument(
     "manuscript_path",
@@ -99,12 +152,16 @@ def _check_and_offer_poppler_installation(console: Console, quiet: bool, verbose
     is_flag=True,
     help="Disable references section (citations only)",
 )
+@click.option("--split-si", is_flag=True, help="Split DOCX into main and SI documents (__main.docx and __si.docx)")
+@click.option("--split-si-pdf", is_flag=True, help="Export main DOCX and SI PDF (__main.docx and __si.pdf)")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress non-essential output")
 def docx(
     manuscript_path: str | None,
     resolve_dois: bool,
     no_footnotes: bool,
+    split_si: bool,
+    split_si_pdf: bool,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -136,7 +193,18 @@ def docx(
     **Without references section (citations only):**
 
         $ rxiv docx --no-footnotes
+
+    **Split main and SI into separate DOCX files:**
+
+        $ rxiv docx --split-si
+
+    **Export main as DOCX and SI as PDF:**
+
+        $ rxiv docx --split-si-pdf
     """
+    if split_si and split_si_pdf:
+        raise click.UsageError("--split-si and --split-si-pdf cannot be used together")
+
     try:
         # Configure logging
         if verbose:
@@ -151,17 +219,53 @@ def docx(
         if not quiet:
             console.print("[cyan]📄 Exporting manuscript to DOCX...[/cyan]")
 
-        exporter = DocxExporter(
-            manuscript_path=manuscript_path,
-            resolve_dois=resolve_dois,
-            include_footnotes=not no_footnotes,
-        )
-
         # Pre-flight check for poppler (if manuscript contains PDF figures)
         _check_and_offer_poppler_installation(console, quiet, verbose)
 
         # Perform export
-        docx_path = exporter.export()
+        if split_si:
+            main_docx_path = _export_docx_file(
+                manuscript_path,
+                resolve_dois,
+                no_footnotes,
+                content_mode="main",
+                output_suffix="__main",
+            )
+            si_docx_path = _export_docx_file(
+                manuscript_path,
+                resolve_dois,
+                no_footnotes,
+                content_mode="si",
+                output_suffix="__si",
+            )
+            if not quiet:
+                console.print("[green]✅ DOCX split successfully:[/green]")
+                console.print(f"   Main: {main_docx_path}")
+                console.print(f"   SI: {si_docx_path}")
+            return
+
+        if split_si_pdf:
+            main_docx_path = _export_docx_file(
+                manuscript_path,
+                resolve_dois,
+                no_footnotes,
+                content_mode="main",
+                output_suffix="__main",
+            )
+            si_pdf_path = _build_and_export_si_pdf(manuscript_path, quiet, verbose)
+            if not quiet:
+                console.print("[green]✅ DOCX/PDF split successfully:[/green]")
+                console.print(f"   Main DOCX: {main_docx_path}")
+                console.print(f"   SI PDF: {si_pdf_path}")
+            return
+
+        docx_path = _export_docx_file(
+            manuscript_path,
+            resolve_dois,
+            no_footnotes,
+            content_mode="full",
+            output_suffix=None,
+        )
 
         # Success message
         if not quiet:

--- a/src/rxiv_maker/cli/main.py
+++ b/src/rxiv_maker/cli/main.py
@@ -126,7 +126,7 @@ click.rich_click.OPTION_GROUPS = {
     "rxiv docx": [
         {
             "name": "Export Options",
-            "options": ["-r", "--resolve-dois", "--no-footnotes"],
+            "options": ["-r", "--resolve-dois", "--no-footnotes", "--split-si", "--split-si-pdf"],
         },
         {
             "name": "Processing Options",

--- a/src/rxiv_maker/exporters/docx_exporter.py
+++ b/src/rxiv_maker/exporters/docx_exporter.py
@@ -33,6 +33,8 @@ class DocxExporter:
         manuscript_path: str,
         resolve_dois: bool = False,
         include_footnotes: bool = True,
+        content_mode: str = "full",
+        output_suffix: str | None = None,
     ):
         """Initialize DOCX exporter.
 
@@ -40,10 +42,17 @@ class DocxExporter:
             manuscript_path: Path to manuscript directory
             resolve_dois: Whether to attempt DOI resolution for missing entries
             include_footnotes: Whether to include DOI footnotes
+            content_mode: Content to export: "full", "main", or "si"
+            output_suffix: Optional suffix to append before .docx
         """
+        if content_mode not in {"full", "main", "si"}:
+            raise ValueError("content_mode must be one of: full, main, si")
+
         self.path_manager = PathManager(manuscript_path=manuscript_path)
         self.resolve_dois = resolve_dois
         self.include_footnotes = include_footnotes
+        self.content_mode = content_mode
+        self.output_suffix = output_suffix
 
         # Load config to get author name format preference and DOCX options
         config_manager = ConfigManager(base_dir=Path(manuscript_path))
@@ -53,6 +62,8 @@ class DocxExporter:
         # DOCX export options
         docx_config = config.get("docx", {})
         self.hide_si = docx_config.get("hide_si", False)  # Default to False (don't hide SI) for backwards compatibility
+        if self.content_mode == "main":
+            self.hide_si = True
         self.figures_at_end = docx_config.get("figures_at_end", False)  # Default to False (inline figures)
         self.hide_highlighting = docx_config.get("hide_highlighting", False)  # Default to False (show highlights)
         self.hide_comments = docx_config.get("hide_comments", False)  # Default to False (include comments)
@@ -78,13 +89,16 @@ class DocxExporter:
             # Generate DOCX name using same pattern as PDF: YEAR__lastname_et_al__rxiv.docx
             pdf_filename = get_custom_pdf_filename(yaml_metadata)
             docx_filename = pdf_filename.replace(".pdf", ".docx")
+            if self.output_suffix:
+                docx_filename = docx_filename.replace(".docx", f"{self.output_suffix}.docx")
 
             return self.path_manager.manuscript_path / docx_filename
         except Exception as e:
             # Fallback to simple name if metadata extraction fails
             logger.warning(f"Could not extract metadata for custom filename: {e}")
             manuscript_name = self.path_manager.manuscript_name
-            return self.path_manager.manuscript_path / f"{manuscript_name}.docx"
+            suffix = self.output_suffix or ""
+            return self.path_manager.manuscript_path / f"{manuscript_name}{suffix}.docx"
 
     def export(self) -> Path:
         """Execute complete DOCX export process.
@@ -287,6 +301,10 @@ class DocxExporter:
         if not main_md.exists():
             raise FileNotFoundError(f"01_MAIN.md not found in {self.path_manager.manuscript_path}")
 
+        supp_md = self.path_manager.manuscript_path / "02_SUPPLEMENTARY_INFO.md"
+        if self.content_mode == "si" and not supp_md.exists():
+            raise FileNotFoundError(f"02_SUPPLEMENTARY_INFO.md not found in {self.path_manager.manuscript_path}")
+
         bib_file = self.path_manager.manuscript_path / "03_REFERENCES.bib"
         if not bib_file.exists():
             raise FileNotFoundError("03_REFERENCES.bib not found (required for citations)")
@@ -307,21 +325,22 @@ class DocxExporter:
         # Get markdown preprocessor for this manuscript
         preprocessor = get_markdown_preprocessor(manuscript_path=str(self.path_manager.manuscript_path))
 
-        # Load 01_MAIN.md
-        main_md = self.path_manager.manuscript_path / "01_MAIN.md"
-        main_content = main_md.read_text(encoding="utf-8")
+        if self.content_mode != "si":
+            # Load 01_MAIN.md
+            main_md = self.path_manager.manuscript_path / "01_MAIN.md"
+            main_content = main_md.read_text(encoding="utf-8")
 
-        # Remove YAML header
-        main_content = remove_yaml_header(main_content)
+            # Remove YAML header
+            main_content = remove_yaml_header(main_content)
 
-        # Process rxiv-maker syntax ({{py:exec}}, {{py:get}}, {{tex:...}})
-        main_content = preprocessor.process(main_content, target_format="docx", file_path="01_MAIN.md")
+            # Process rxiv-maker syntax ({{py:exec}}, {{py:get}}, {{tex:...}})
+            main_content = preprocessor.process(main_content, target_format="docx", file_path="01_MAIN.md")
 
-        content.append(main_content)
+            content.append(main_content)
 
         # Load 02_SUPPLEMENTARY_INFO.md if exists and not configured to hide SI
         supp_md = self.path_manager.manuscript_path / "02_SUPPLEMENTARY_INFO.md"
-        if supp_md.exists() and not self.hide_si:
+        if supp_md.exists() and (self.content_mode == "si" or not self.hide_si):
             logger.info("Including supplementary information")
             supp_content = supp_md.read_text(encoding="utf-8")
             supp_content = remove_yaml_header(supp_content)
@@ -332,7 +351,8 @@ class DocxExporter:
             )
 
             # Add page break and SI title before supplementary content
-            content.append("<!-- PAGE_BREAK -->")
+            if self.content_mode != "si":
+                content.append("<!-- PAGE_BREAK -->")
             content.append("# Supplementary Information")
             content.append(supp_content)
         elif supp_md.exists() and self.hide_si:

--- a/tests/cli/test_docx.py
+++ b/tests/cli/test_docx.py
@@ -1,0 +1,76 @@
+"""Test DOCX command options."""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from rxiv_maker.cli.commands.docx import docx
+
+
+class TestDocxCommand:
+    """Test DOCX command functionality."""
+
+    def setup_method(self):
+        """Set up test environment."""
+        self.runner = CliRunner()
+
+    def test_docx_help_shows_split_options(self):
+        """Test DOCX command help includes split options."""
+        result = self.runner.invoke(docx, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--split-si" in result.output
+        assert "--split-si-pdf" in result.output
+
+    def test_split_options_are_mutually_exclusive(self, tmp_path):
+        """Test split-si and split-si-pdf cannot be combined."""
+        manuscript_dir = tmp_path / "MANUSCRIPT"
+        manuscript_dir.mkdir()
+
+        result = self.runner.invoke(docx, [str(manuscript_dir), "--split-si", "--split-si-pdf"])
+
+        assert result.exit_code != 0
+        assert "cannot be used together" in result.output
+
+    def test_split_si_exports_main_and_si_docx(self, tmp_path):
+        """Test split-si exports main and SI DOCX artifacts."""
+        manuscript_dir = tmp_path / "MANUSCRIPT"
+        manuscript_dir.mkdir()
+        main_path = manuscript_dir / "paper__main.docx"
+        si_path = manuscript_dir / "paper__si.docx"
+
+        with (
+            patch("rxiv_maker.cli.commands.docx._check_and_offer_poppler_installation"),
+            patch(
+                "rxiv_maker.cli.commands.docx._export_docx_file",
+                side_effect=[main_path, si_path],
+            ) as mock_export,
+        ):
+            result = self.runner.invoke(docx, [str(manuscript_dir), "--split-si"])
+
+        assert result.exit_code == 0
+        assert mock_export.call_count == 2
+        assert mock_export.call_args_list[0].kwargs["content_mode"] == "main"
+        assert mock_export.call_args_list[0].kwargs["output_suffix"] == "__main"
+        assert mock_export.call_args_list[1].kwargs["content_mode"] == "si"
+        assert mock_export.call_args_list[1].kwargs["output_suffix"] == "__si"
+
+    def test_split_si_pdf_exports_main_docx_and_si_pdf(self, tmp_path):
+        """Test split-si-pdf exports main DOCX and SI PDF artifacts."""
+        manuscript_dir = tmp_path / "MANUSCRIPT"
+        manuscript_dir.mkdir()
+        main_path = manuscript_dir / "paper__main.docx"
+        si_path = manuscript_dir / "paper__si.pdf"
+
+        with (
+            patch("rxiv_maker.cli.commands.docx._check_and_offer_poppler_installation"),
+            patch("rxiv_maker.cli.commands.docx._export_docx_file", return_value=main_path) as mock_export,
+            patch("rxiv_maker.cli.commands.docx._build_and_export_si_pdf", return_value=si_path) as mock_pdf,
+        ):
+            result = self.runner.invoke(docx, [str(manuscript_dir), "--split-si-pdf"])
+
+        assert result.exit_code == 0
+        mock_export.assert_called_once()
+        assert mock_export.call_args.kwargs["content_mode"] == "main"
+        assert mock_export.call_args.kwargs["output_suffix"] == "__main"
+        mock_pdf.assert_called_once_with(str(manuscript_dir), False, False)

--- a/tests/cli/test_docx.py
+++ b/tests/cli/test_docx.py
@@ -1,10 +1,18 @@
 """Test DOCX command options."""
 
+import importlib
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from rxiv_maker.cli.commands.docx import docx
+
+# NOTE: ``rxiv_maker.cli.commands`` re-exports the ``docx`` command (see its
+# ``__init__``), which shadows the ``docx`` submodule on the package, so neither
+# a dotted patch target ("rxiv_maker.cli.commands.docx.<fn>") nor ``import ... as``
+# resolves to the module reliably across Python versions. Fetch the real module
+# object explicitly so ``patch.object`` binds the helper functions.
+docx_module = importlib.import_module("rxiv_maker.cli.commands.docx")
 
 
 class TestDocxCommand:
@@ -40,9 +48,10 @@ class TestDocxCommand:
         si_path = manuscript_dir / "paper__si.docx"
 
         with (
-            patch("rxiv_maker.cli.commands.docx._check_and_offer_poppler_installation"),
-            patch(
-                "rxiv_maker.cli.commands.docx._export_docx_file",
+            patch.object(docx_module, "_check_and_offer_poppler_installation"),
+            patch.object(
+                docx_module,
+                "_export_docx_file",
                 side_effect=[main_path, si_path],
             ) as mock_export,
         ):
@@ -63,9 +72,9 @@ class TestDocxCommand:
         si_path = manuscript_dir / "paper__si.pdf"
 
         with (
-            patch("rxiv_maker.cli.commands.docx._check_and_offer_poppler_installation"),
-            patch("rxiv_maker.cli.commands.docx._export_docx_file", return_value=main_path) as mock_export,
-            patch("rxiv_maker.cli.commands.docx._build_and_export_si_pdf", return_value=si_path) as mock_pdf,
+            patch.object(docx_module, "_check_and_offer_poppler_installation"),
+            patch.object(docx_module, "_export_docx_file", return_value=main_path) as mock_export,
+            patch.object(docx_module, "_build_and_export_si_pdf", return_value=si_path) as mock_pdf,
         ):
             result = self.runner.invoke(docx, [str(manuscript_dir), "--split-si-pdf"])
 

--- a/tests/integration/test_docx_export_integration.py
+++ b/tests/integration/test_docx_export_integration.py
@@ -1,5 +1,6 @@
 """Integration tests for DOCX export."""
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -74,6 +75,44 @@ class TestDocxExportIntegration:
 
         # Check for supplementary content
         assert "Supplementary" in all_text
+
+    def test_export_main_only_with_split_suffix(self, sample_manuscript_path, tmp_path):
+        """Test exporting only main content with split DOCX naming."""
+        manuscript_copy = tmp_path / "sample_manuscript"
+        shutil.copytree(sample_manuscript_path, manuscript_copy)
+
+        exporter = DocxExporter(
+            manuscript_path=str(manuscript_copy),
+            content_mode="main",
+            output_suffix="__main",
+        )
+
+        result_path = exporter.export()
+        doc = Document(str(result_path))
+        all_text = "\n".join([p.text for p in doc.paragraphs])
+
+        assert result_path.name.endswith("__main.docx")
+        assert "Introduction" in all_text
+        assert "Supplementary Information" not in all_text
+
+    def test_export_si_only_with_split_suffix(self, sample_manuscript_path, tmp_path):
+        """Test exporting only SI content with split DOCX naming."""
+        manuscript_copy = tmp_path / "sample_manuscript"
+        shutil.copytree(sample_manuscript_path, manuscript_copy)
+
+        exporter = DocxExporter(
+            manuscript_path=str(manuscript_copy),
+            content_mode="si",
+            output_suffix="__si",
+        )
+
+        result_path = exporter.export()
+        doc = Document(str(result_path))
+        all_text = "\n".join([p.text for p in doc.paragraphs])
+
+        assert result_path.name.endswith("__si.docx")
+        assert "Supplementary" in all_text
+        assert "Introduction" not in all_text
 
     def test_export_preserves_formatting(self, sample_manuscript_path, tmp_path):
         """Test that inline formatting is preserved."""


### PR DESCRIPTION
This PR enables the --split-si and --split-si-pdf arguments to rxiv docx command:
- split-si will generate _main.docx and _si.docx
- split-si-pdf will generate _main.docx and _si.pdf

This should be helpful tor journal submissions