### PR TITLE
fix(test): unblock Coverage Validation; release 1.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.3] - 2026-06-09
+
+### Fixed
+- CI: the `changelog` command test no longer breaks on version bumps. The
+  default-version test now injects the current `__version__` into the mocked
+  changelog content instead of relying on a hard-coded fixture entry, so the
+  `Coverage Validation` check stays green across releases. (#307)
+
 ## [1.20.2] - 2026-06-02
 
 ### Fixed

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.20.2"
+__version__ = "1.20.3"

--- a/tests/cli/test_changelog_command.py
+++ b/tests/cli/test_changelog_command.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
+from rxiv_maker import __version__
 from rxiv_maker.cli.commands.changelog import changelog
 
 
@@ -156,14 +157,24 @@ class TestChangelogCommand:
 
     @patch("rxiv_maker.cli.commands.changelog.fetch_changelog")
     def test_changelog_default_shows_current_version(self, mock_fetch, runner, sample_changelog):
-        """Test that default command shows current version."""
-        mock_fetch.return_value = sample_changelog
+        """Test that default command shows current version.
+
+        The default command looks up ``__version__`` in the changelog, so the
+        mocked content must contain an entry for whatever the current version
+        is. Inject one for ``__version__`` (rather than hard-coding a version
+        into the shared fixture) so this test keeps passing across version
+        bumps and does not perturb the version-counting tests that rely on the
+        fixture's exact ordering.
+        """
+        current_entry = f"## [v{__version__}] - 2026-06-09\n\n### Fixed\n- Current release entry for testing\n\n"
+        mock_fetch.return_value = sample_changelog.replace("# Changelog\n\n", f"# Changelog\n\n{current_entry}", 1)
 
         result = runner.invoke(changelog)
 
         assert result.exit_code == 0
         output = strip_ansi(result.output)
         assert "Version" in output
+        assert f"{__version__}" in output
         assert "Fetching changelog" in output
 
     @patch("rxiv_maker.cli.commands.changelog.fetch_changelog")


### PR DESCRIPTION
## Summary

Fixes the pre-existing `Coverage Validation` CI failure that marked every PR **UNSTABLE**, and bumps to **1.20.3**.

`tests/cli/test_changelog_command.py::test_changelog_default_shows_current_version` was exiting 1 because the default `rxiv changelog` path looks up `__version__`, but the mocked `sample_changelog` fixture topped out at `v1.20.1` while `__version__` had moved to `1.20.2`. `parse_version_entry` returned `None` → `sys.exit(1)` → `assert 1 == 0`. This was the sole reason `Coverage Validation` was red (the coverage threshold itself passes at ~43.5% ≥ 40%).

## Fix

The default test now injects an entry for the current `__version__` into the mocked content instead of relying on a hard-coded fixture version. This keeps it green across future version bumps, and avoids perturbing the version-counting tests (`--since`, `--recent`) that depend on the shared fixture's exact ordering.

## Release

- Bumps `src/rxiv_maker/__version__.py` to `1.20.3`
- Adds the matching `## [1.20.3]` CHANGELOG entry

## Verification

- `pytest tests/cli/test_changelog_command.py` → 19 passed, 1 skipped (pre-existing env skip) on Python 3.11
- All pre-commit hooks pass (ruff, ruff-format, bandit, typos, docs validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)