### PR TITLE
Release 1.20.4: table-cell citation underscores + accented filename transliteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.4] - 2026-06-12
+
+### Fixed
+- Tables: citation keys containing underscores (e.g. `Xie2016_bookdown`) no
+  longer break bibtex when cited inside a Markdown table cell under the
+  author-date citation style. The underscore-protection now covers the full
+  citation family (`\cite`, `\citep`, `\citet`); previously only `\cite` was
+  protected, so author-date citations were escaped to `\citep{Xie2016\_bookdown}`,
+  producing a malformed `.aux` entry that aborted the entire bibliography with a
+  "White space in argument" error.
+- Output filenames: accented lead-author names are now transliterated to plain
+  ASCII (e.g. `Martínez` → `2026__martinez_et_al__rxiv.pdf`). Non-ASCII filenames
+  could break on systems that cannot handle latin1 filenames. Applies to both
+  PDF and DOCX output.
+
 ## [1.20.3] - 2026-06-09
 
 ### Added

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.20.3"
+__version__ = "1.20.4"

--- a/src/rxiv_maker/converters/table_processor.py
+++ b/src/rxiv_maker/converters/table_processor.py
@@ -774,13 +774,23 @@ def _split_on_latex_commands(text: str, commands: list[str]) -> list[str]:
 
 
 def _escape_underscores_outside_cite(text: str) -> str:
-    r"""Escape underscores but not inside \cite{} commands."""
-    # Split text on cite commands to preserve them
-    parts = re.split(r"(\\cite\{[^}]*\})", text)
+    r"""Escape underscores but not inside citation commands.
+
+    Citation keys frequently contain underscores (e.g. ``Xie2016_bookdown``). Those
+    underscores must be preserved verbatim inside the citation command argument,
+    otherwise LaTeX writes ``\citation{Xie2016\protect \T1\textunderscore bookdown}``
+    to the .aux file and bibtex aborts the whole bibliography with a
+    "White space in argument" error.
+
+    Covers all citation commands the translator can emit: ``\cite`` (numbered) plus
+    ``\citep``/``\citet`` (author-date style).
+    """
+    # Split text on citation commands to preserve them
+    parts = re.split(r"(\\cite[a-zA-Z]*\{[^}]*\})", text)
     result: list[str] = []
     for part in parts:
-        if part.startswith("\\cite{"):
-            # Don't escape underscores inside cite commands
+        if re.match(r"^\\cite[a-zA-Z]*\{", part):
+            # Don't escape underscores inside citation commands
             result.append(part)
         else:
             # Escape underscores in regular text
@@ -791,11 +801,13 @@ def _escape_underscores_outside_cite(text: str) -> str:
 
 def _escape_outside_latex_commands(text: str) -> str:
     """Escape special characters outside LaTeX formatting commands."""
-    # Split on all LaTeX formatting and reference commands to protect them
-    parts = _split_on_latex_commands(text, ["texttt", "textbf", "textit", "ref", "cite"])
+    # Split on all LaTeX formatting and reference commands to protect them.
+    # Include the full citation family (\cite, \citep, \citet) so underscore-bearing
+    # citation keys are never escaped inside their argument.
+    parts = _split_on_latex_commands(text, ["texttt", "textbf", "textit", "ref", "cite", "citep", "citet"])
     result: list[str] = []
     for _i, part in enumerate(parts):
-        if part.startswith(("\\texttt{", "\\textbf{", "\\textit{", "\\ref{", "\\cite{")):
+        if part.startswith(("\\texttt{", "\\textbf{", "\\textit{", "\\ref{", "\\cite{", "\\citep{", "\\citet{")):
             # For code blocks, ensure % is escaped so it doesn't start a LaTeX comment
             if part.startswith("\\texttt{"):
                 # Replace unescaped % with \%

--- a/src/rxiv_maker/utils/pdf_utils.py
+++ b/src/rxiv_maker/utils/pdf_utils.py
@@ -2,11 +2,56 @@
 
 import os
 import shutil
+import unicodedata
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from .platform import safe_print
+
+# Common Latin letters that do not decompose under NFKD normalization and so
+# need an explicit ASCII transliteration (e.g. ø, ß, ł).
+_NON_DECOMPOSABLE_TRANSLITERATIONS = {
+    "ø": "o",
+    "Ø": "O",
+    "ß": "ss",
+    "ł": "l",
+    "Ł": "L",
+    "đ": "d",
+    "Đ": "D",
+    "ð": "d",
+    "Ð": "D",
+    "þ": "th",
+    "Þ": "Th",
+    "æ": "ae",
+    "Æ": "Ae",
+    "œ": "oe",
+    "Œ": "Oe",
+    "ı": "i",
+}
+
+
+def _strip_accents(text: str) -> str:
+    """Transliterate accented characters to plain ASCII.
+
+    Converts characters like ``í`` -> ``i`` and ``ñ`` -> ``n`` so that generated
+    filenames are portable to systems that cannot handle non-ASCII (e.g. latin1)
+    filenames. Letters that do not decompose under NFKD (ø, ß, ł, ...) are mapped
+    explicitly; any remaining non-ASCII characters are dropped.
+
+    Args:
+        text: The text to transliterate.
+
+    Returns:
+        An ASCII-only version of the input text.
+    """
+    # Handle explicit transliterations first (these do not decompose via NFKD).
+    text = "".join(_NON_DECOMPOSABLE_TRANSLITERATIONS.get(ch, ch) for ch in text)
+    # Decompose remaining accented characters and drop the combining marks.
+    decomposed = unicodedata.normalize("NFKD", text)
+    without_marks = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    # Drop any non-ASCII characters that still remain.
+    return without_marks.encode("ascii", "ignore").decode("ascii")
 
 
 def get_custom_pdf_filename(yaml_metadata: dict[str, Any]) -> str:
@@ -40,8 +85,9 @@ def get_custom_pdf_filename(yaml_metadata: dict[str, Any]) -> str:
     else:
         lead_author = "unknown"
 
-    # Clean the lead author name (remove spaces, make lowercase)
-    lead_author_clean = lead_author.lower().replace(" ", "_").replace(".", "")
+    # Clean the lead author name: strip accents (for filesystem portability),
+    # remove spaces, make lowercase.
+    lead_author_clean = _strip_accents(lead_author).lower().replace(" ", "_").replace(".", "")
 
     # Generate filename: year__lead_author_et_al__rxiv.pdf
     filename = f"{year}__{lead_author_clean}_et_al__rxiv.pdf"

--- a/tests/unit/test_table_citation_underscore.py
+++ b/tests/unit/test_table_citation_underscore.py
@@ -1,0 +1,68 @@
+"""Regression tests for underscore-bearing citation keys inside table cells.
+
+A citation key containing an underscore (e.g. ``Xie2016_bookdown``) cited inside a
+Markdown table cell must NOT have its underscore LaTeX-escaped. If the underscore is
+escaped to ``\\_`` inside a ``\\cite``/``\\citep``/``\\citet`` argument, LaTeX writes
+``\\citation{Some\\protect \\T1\\textunderscore Key}`` to the .aux file, and bibtex
+then aborts with "White space in argument", losing the entire bibliography.
+
+See: underscore citation keys break bibtex when cited inside a table cell.
+"""
+
+import unittest
+
+from rxiv_maker.converters.table_processor import (
+    _format_regular_table_cell,
+    convert_tables_to_latex,
+)
+
+
+class TestTableCitationUnderscore(unittest.TestCase):
+    """Citation keys with underscores must survive table-cell processing unescaped."""
+
+    def test_numbered_citation_key_underscore_unescaped(self):
+        """``[@Some_Key]`` -> ``\\cite{Some_Key}`` (numbered style)."""
+        result = _format_regular_table_cell("[@Some_Key]", citation_style="numbered")
+        self.assertIn("\\cite{Some_Key}", result)
+        self.assertNotIn("Some\\_Key", result)
+        self.assertNotIn("textunderscore", result)
+
+    def test_authordate_bracketed_citation_key_underscore_unescaped(self):
+        """``[@Some_Key]`` -> ``\\citep{Some_Key}`` (author-date style)."""
+        result = _format_regular_table_cell("[@Some_Key]", citation_style="author-date")
+        self.assertIn("\\citep{Some_Key}", result)
+        self.assertNotIn("Some\\_Key", result)
+        self.assertNotIn("textunderscore", result)
+
+    def test_authordate_inline_citation_key_underscore_unescaped(self):
+        """``@Some_Key`` -> ``\\citet{Some_Key}`` (author-date style)."""
+        result = _format_regular_table_cell("@Some_Key", citation_style="author-date")
+        self.assertIn("\\citet{Some_Key}", result)
+        self.assertNotIn("Some\\_Key", result)
+        self.assertNotIn("textunderscore", result)
+
+    def test_bold_plus_underscore_citation_authordate(self):
+        """Real-world cell: ``**Bookdown** [@Xie2016_bookdown]`` (author-date)."""
+        result = _format_regular_table_cell("**Bookdown** [@Xie2016_bookdown]", citation_style="author-date")
+        self.assertIn("\\citep{Xie2016_bookdown}", result)
+        self.assertNotIn("Xie2016\\_bookdown", result)
+
+    def test_underscore_in_surrounding_text_still_escaped(self):
+        """Underscores OUTSIDE the citation argument must still be escaped."""
+        result = _format_regular_table_cell("see [@Some_Key] and file_name", citation_style="author-date")
+        # Citation key preserved...
+        self.assertIn("\\citep{Some_Key}", result)
+        # ...but the plain-text underscore is escaped for LaTeX.
+        self.assertIn("file\\_name", result)
+
+    def test_full_table_authordate_citation_underscore(self):
+        """End-to-end through convert_tables_to_latex with author-date style."""
+        markdown = "| Tool | Ref |\n|------|-----|\n| Bookdown | [@Xie2016_bookdown] |\n"
+        result = convert_tables_to_latex(markdown, citation_style="author-date")
+        self.assertIn("\\citep{Xie2016_bookdown}", result)
+        self.assertNotIn("Xie2016\\_bookdown", result)
+        self.assertNotIn("textunderscore", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -143,14 +143,15 @@ class TestUtils:
         result = get_custom_pdf_filename(yaml_metadata)
         assert result == "2025__smith_et_al__rxiv.pdf"
 
-        # Test with different author format (list)
+        # Test with different author format (list). Accented characters are
+        # transliterated to plain ASCII for filesystem portability.
         yaml_metadata_list = {
             "date": "2024-12-01",
             "title": [{"lead_author": "García-López"}, {"other": "data"}],
         }
 
         result = get_custom_pdf_filename(yaml_metadata_list)
-        assert result == "2024__garcía-lópez_et_al__rxiv.pdf"
+        assert result == "2024__garcia-lopez_et_al__rxiv.pdf"
 
         # Test with missing metadata (fallback to current year and unknown)
         import datetime
@@ -160,6 +161,24 @@ class TestUtils:
         yaml_metadata_minimal = {}
         result = get_custom_pdf_filename(yaml_metadata_minimal)
         assert result == f"{current_year}__unknown_et_al__rxiv.pdf"
+
+    def test_get_custom_pdf_filename_strips_accents(self):
+        """Accented author names are transliterated to ASCII for portable filenames."""
+        cases = {
+            "Martínez": "2026__martinez_et_al__rxiv.pdf",
+            "Müller": "2026__muller_et_al__rxiv.pdf",
+            "Núñez": "2026__nunez_et_al__rxiv.pdf",
+            "Gonçalves": "2026__goncalves_et_al__rxiv.pdf",
+            "Łukasiewicz": "2026__lukasiewicz_et_al__rxiv.pdf",
+            "Møller": "2026__moller_et_al__rxiv.pdf",
+            "Straße": "2026__strasse_et_al__rxiv.pdf",
+        }
+        for author, expected in cases.items():
+            yaml_metadata = {"date": "2026-01-01", "title": {"lead_author": author}}
+            result = get_custom_pdf_filename(yaml_metadata)
+            assert result == expected, f"{author!r} -> {result!r}, expected {expected!r}"
+            # Resulting filename (minus the .pdf extension marker) must be pure ASCII.
+            result.encode("ascii")
 
     def test_copy_pdf_to_manuscript_folder_success(self, temp_dir, monkeypatch):
         """Test successfully copying PDF to manuscript folder with custom naming."""
@@ -615,8 +634,8 @@ This research presents breakthrough findings.
 
         copied_pdf = copy_pdf_to_manuscript_folder(str(output_dir), yaml_metadata)
 
-        # Should clean special characters appropriately
-        expected_pdf_name = "2025__garcía-lópez_o'connor_et_al__rxiv.pdf"
+        # Should clean special characters appropriately (accents transliterated to ASCII)
+        expected_pdf_name = "2025__garcia-lopez_o'connor_et_al__rxiv.pdf"
         expected_pdf_path = manuscript_dir / expected_pdf_name
 
         assert copied_pdf.resolve() == expected_pdf_path.resolve()


### PR DESCRIPTION
## Summary

Patch release **1.20.4** bundling two bug fixes. The `v1.20.4` tag has been pushed and the PyPI release pipeline is already running from the tagged commit; this PR lands the same commits on `main`.

### Fixes

- **Tables — author-date citation underscores break bibtex.** Citation keys containing underscores (e.g. `Xie2016_bookdown`) cited inside a Markdown table cell under the author-date style were escaped to `\citep{Xie2016\_bookdown}`, producing a malformed `.aux` entry that aborted the entire bibliography ("White space in argument"). The underscore-protection in the table converter now covers the full citation family (`\cite`, `\citep`, `\citet`); previously only `\cite` was protected. The numbered `\cite{}` path was already fixed in v1.15.0.

- **Output filenames — accented author names.** Accented lead-author names produced non-ASCII output filenames (e.g. `2026__martínez_et_al__rxiv.pdf`), which break on systems that can't handle latin1 filenames. Names are now transliterated to plain ASCII (`Martínez` → `2026__martinez_et_al__rxiv.pdf`). NFKD normalization handles most accents; an explicit map covers non-decomposable Latin letters (ø, ß, ł, đ, ð, þ, æ, œ, ı). Applies to both PDF and DOCX (shared code path).

## Tests

- New `tests/unit/test_table_citation_underscore.py` — 6 regression tests (numbered + author-date, bracketed + inline, full-table end-to-end, plain-text underscore still escaped).
- New `test_get_custom_pdf_filename_strips_accents` plus updates to existing filename tests that previously expected accented output.
- Related suites pass locally (table/citation/md2tex/supplementary, utils, changelog, docx naming).

## Release

- `src/rxiv_maker/__version__.py` → `1.20.4`
- `CHANGELOG.md` → `[1.20.4] - 2026-06-12`

🤖 Generated with [Claude Code](https://claude.com/claude-code)