### PR TITLE
feat(docx): render {{tex}} tables as images; fix SI table captions & numbering (1.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-06-18
+
+### Added
+- DOCX: raw `{{tex:...}}` tables are now rendered to an image and embedded in the
+  Word output instead of being replaced by a "refer to the PDF version"
+  placeholder. The table LaTeX is compiled standalone (pdflatex → pdftoppm) and
+  any `\cite{...}` inside it is resolved to the document's citation numbers so the
+  image matches the surrounding text. `longtable` blocks are converted to a single
+  `tabular` for the still image. Behaviour is on by default with automatic
+  fallback to the previous textual placeholder if a table cannot be rendered (no
+  LaTeX toolchain, or a block that fails to compile).
+
+### Fixed
+- DOCX: standalone supplementary-table caption markers no longer leak into the Word
+  output. A `{#stable:label}` caption that precedes a `{{tex}}` table (or the
+  `%{#stable:label}` variant whose `%` hides the marker from LaTeX) was emitted
+  verbatim instead of rendered; it is now formatted as `Supp. Table SN. <caption>`,
+  matching captions attached to Markdown tables.
+- DOCX: supplementary tables are numbered correctly when a manuscript mixes label
+  styles. Table numbering now counts both `{#stable:label}` and `\label{stable:label}`
+  forms in document order; previously a single LaTeX `\label` (e.g. inside a `{{tex}}`
+  table) caused all Markdown-labelled tables to be dropped from the numbering.
+
 ## [1.20.4] - 2026-06-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tabular` for the still image. Behaviour is on by default with automatic
   fallback to the previous textual placeholder if a table cannot be rendered (no
   LaTeX toolchain, or a block that fails to compile).
+- DOCX: new `--tables-as-images` option (CLI flag, or `docx.tables_as_images: true`
+  in config) renders *Markdown* tables as images too, so every table shares one
+  style with `{{tex}}` tables and matches the PDF. Off by default (Markdown tables
+  stay native, editable Word tables). Reuses the PDF Markdown-to-LaTeX table
+  converter; cross-references and citations in cells are already resolved to text.
 
 ### Fixed
 - DOCX: standalone supplementary-table caption markers no longer leak into the Word

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DOCX: standalone supplementary-table caption markers no longer leak into the Word
   output. A `{#stable:label}` caption that precedes a `{{tex}}` table (or the
   `%{#stable:label}` variant whose `%` hides the marker from LaTeX) was emitted
-  verbatim instead of rendered; it is now formatted as `Supp. Table SN. <caption>`,
-  matching captions attached to Markdown tables.
+  verbatim instead of rendered; it is now formatted as `Supp. Table SN. <caption>`
+  and placed directly below the table image (matching Markdown-table/PDF caption
+  placement), kept on the same page as the table.
 - DOCX: supplementary tables are numbered correctly when a manuscript mixes label
   styles. Table numbering now counts both `{#stable:label}` and `\label{stable:label}`
   forms in document order; previously a single LaTeX `\label` (e.g. inside a `{{tex}}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DOCX: raw `{{tex:...}}` tables are now rendered to an image and embedded in the
   Word output instead of being replaced by a "refer to the PDF version"
   placeholder. The table LaTeX is compiled standalone (pdflatex → pdftoppm) and
-  any `\cite{...}` inside it is resolved to the document's citation numbers so the
-  image matches the surrounding text. `longtable` blocks are converted to a single
+  any numeric citation command inside it (`\cite`, `\citep`, `\citet`, `\autocite`,
+  `\parencite`, `\textcite`, `\citenum`) is resolved to the document's citation
+  numbers so the image matches the surrounding text. `longtable` blocks are converted to a single
   `tabular` for the still image. Behaviour is on by default with automatic
   fallback to the previous textual placeholder if a table cannot be rendered (no
   LaTeX toolchain, or a block that fails to compile).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -279,6 +279,9 @@ rxiv docx --split-si
 
 # Export main text as DOCX and SI as PDF
 rxiv docx --split-si-pdf
+
+# Render every table as an image (one consistent style, matching the PDF)
+rxiv docx --tables-as-images
 ```
 
 **Options**:
@@ -287,8 +290,11 @@ rxiv docx --split-si-pdf
 - `--no-footnotes` - Disable DOI footnotes/references section
 - `--split-si` - Output `__main.docx` and `__si.docx`
 - `--split-si-pdf` - Output `__main.docx` and `__si.pdf`
+- `--tables-as-images` - Render Markdown tables as images too, so they share one style with `{{tex}}` tables and match the PDF (off by default; Markdown tables otherwise stay native, editable Word tables)
 - `--verbose` - Detailed output for debugging
 - `--quiet` - Minimal output
+
+**Tables**: complex `{{tex:...}}` (raw LaTeX) tables are rendered as images and embedded automatically, since Word cannot run LaTeX. Markdown tables become native, editable Word tables by default; use `--tables-as-images` (or set `docx.tables_as_images: true` in `00_CONFIG.yml`) to render those as images as well.
 
 ---
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -745,7 +745,7 @@ rxiv track-changes submitted-version revision-version \
 
 ### 📄 Exporting to Word (DOCX)
 
-Collaborate with colleagues who don't use LaTeX/Markdown by exporting to DOCX. The export preserves formatting, figures, and citations.
+Collaborate with colleagues who don't use LaTeX/Markdown by exporting to DOCX. The export preserves formatting, figures, tables, and citations.
 
 ```bash
 # Export to DOCX
@@ -759,10 +759,14 @@ rxiv docx --split-si
 
 # Export main text as DOCX and supplementary information as PDF
 rxiv docx --split-si-pdf
+
+# Render every table as an image (one consistent style, matching the PDF)
+rxiv docx --tables-as-images
 ```
 
 **Features:**
 - **Figures**: Embedded as high-quality images
+- **Tables**: Markdown tables become native, editable Word tables. Complex `{{tex:...}}` (raw LaTeX) tables are rendered as images and embedded automatically (Word cannot run LaTeX), with their `\cite` references resolved to the document's citation numbers. Use `--tables-as-images` (or `docx.tables_as_images: true` in `00_CONFIG.yml`) to render *all* tables as images so they share one style and match the PDF.
 - **Citations**: Converted to numbered [1] or Author-Date (Smith, 2024) style
 - **Formatting**: Bold, italic, underline, and superscripts preserved
 - **References**: Full bibliography generated at the end of manuscript, but prior to Supplementary Information

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.20.4"
+__version__ = "1.21.0"

--- a/src/rxiv_maker/cli/commands/docx.py
+++ b/src/rxiv_maker/cli/commands/docx.py
@@ -89,6 +89,7 @@ def _export_docx_file(
     no_footnotes: bool,
     content_mode: str,
     output_suffix: str | None,
+    tables_as_images: bool = False,
 ) -> Path:
     """Export one DOCX artifact and return its path."""
     exporter = DocxExporter(
@@ -97,6 +98,7 @@ def _export_docx_file(
         include_footnotes=not no_footnotes,
         content_mode=content_mode,
         output_suffix=output_suffix,
+        tables_as_images=tables_as_images,
     )
     return exporter.export()
 
@@ -154,6 +156,11 @@ def _build_and_export_si_pdf(manuscript_path: str, quiet: bool, verbose: bool) -
 )
 @click.option("--split-si", is_flag=True, help="Split DOCX into main and SI documents (__main.docx and __si.docx)")
 @click.option("--split-si-pdf", is_flag=True, help="Export main DOCX and SI PDF (__main.docx and __si.pdf)")
+@click.option(
+    "--tables-as-images",
+    is_flag=True,
+    help="Render Markdown tables as images too (like {{tex}} tables), so all tables share one style",
+)
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress non-essential output")
 def docx(
@@ -162,6 +169,7 @@ def docx(
     no_footnotes: bool,
     split_si: bool,
     split_si_pdf: bool,
+    tables_as_images: bool,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -230,6 +238,7 @@ def docx(
                 no_footnotes,
                 content_mode="main",
                 output_suffix="__main",
+                tables_as_images=tables_as_images,
             )
             si_docx_path = _export_docx_file(
                 manuscript_path,
@@ -237,6 +246,7 @@ def docx(
                 no_footnotes,
                 content_mode="si",
                 output_suffix="__si",
+                tables_as_images=tables_as_images,
             )
             if not quiet:
                 console.print("[green]✅ DOCX split successfully:[/green]")
@@ -251,6 +261,7 @@ def docx(
                 no_footnotes,
                 content_mode="main",
                 output_suffix="__main",
+                tables_as_images=tables_as_images,
             )
             si_pdf_path = _build_and_export_si_pdf(manuscript_path, quiet, verbose)
             if not quiet:
@@ -265,6 +276,7 @@ def docx(
             no_footnotes,
             content_mode="full",
             output_suffix=None,
+            tables_as_images=tables_as_images,
         )
 
         # Success message

--- a/src/rxiv_maker/exporters/docx_content_processor.py
+++ b/src/rxiv_maker/exporters/docx_content_processor.py
@@ -9,6 +9,26 @@ from typing import Any, Dict, List, Optional
 
 from ..utils.comment_filter import is_metadata_comment
 
+# Real LaTeX citations only: a backslash immediately followed by "cite{...}".
+# Escaped display forms such as "\textbackslash cite\{x\}" (used in syntax-reference
+# tables) deliberately do not match, so they are left verbatim in the rendered image.
+_CITE_RE = re.compile(r"\\cite\{([^{}]+)\}")
+
+
+def resolve_latex_citations(latex: str, citation_map: Dict[str, int]) -> str:
+    r"""Replace ``\cite{key,...}`` with the DOCX citation numbers, e.g. ``[7, 12]``.
+
+    Keys present in ``citation_map`` become their number; unknown keys are kept
+    verbatim so attribution is never silently dropped.
+    """
+
+    def _sub(match: "re.Match[str]") -> str:
+        keys = [k.strip() for k in match.group(1).split(",") if k.strip()]
+        parts = [str(citation_map[k]) if k in citation_map else k for k in keys]
+        return "[" + ", ".join(parts) + "]"
+
+    return _CITE_RE.sub(_sub, latex)
+
 
 class DocxContentProcessor:
     """Parses markdown content into structured format for DOCX writing."""
@@ -55,6 +75,18 @@ class DocxContentProcessor:
             if line.strip() == "<!-- PAGE_BREAK -->":
                 sections.append({"type": "page_break"})
                 i += 1
+                continue
+
+            # Check for a preserved {{tex}} table block (emitted by the preprocessor).
+            if line.strip() == "<<TEX_TABLE_START>>":
+                tex_lines = []
+                i += 1
+                while i < len(lines) and lines[i].strip() != "<<TEX_TABLE_END>>":
+                    tex_lines.append(lines[i])
+                    i += 1
+                i += 1  # skip the <<TEX_TABLE_END>> line
+                latex = resolve_latex_citations("\n".join(tex_lines).strip(), citation_map)
+                sections.append({"type": "tex_table", "latex": latex})
                 continue
 
             # Parse HTML/markdown comments (single-line and multi-line)
@@ -104,6 +136,23 @@ class DocxContentProcessor:
                 title_text = re.sub(r"^\*\*(.+?)\*\*$", r"\1", title_text)
                 # Treat as a heading with special formatting
                 sections.append({"type": "snote_title", "label": label, "text": title_text})
+                i += 1
+                continue
+
+            # Check for a standalone table-caption line: {#stable:label} Caption or
+            # %{#stable:label} Caption (the % variant hides the marker from LaTeX when
+            # the real caption lives inside a following {{tex}} block). Captions that
+            # directly follow a Markdown table are consumed by _parse_table instead, so
+            # anything reaching here is an orphaned caption that would otherwise leak.
+            table_caption_match = re.match(r"^%?\{#(stable|table):([\w-]+)\}\s*(.+)$", line.strip())
+            if table_caption_match:
+                sections.append(
+                    {
+                        "type": "table_caption",
+                        "label": f"{table_caption_match.group(1)}:{table_caption_match.group(2)}",
+                        "caption": table_caption_match.group(3).strip(),
+                    }
+                )
                 i += 1
                 continue
 

--- a/src/rxiv_maker/exporters/docx_content_processor.py
+++ b/src/rxiv_maker/exporters/docx_content_processor.py
@@ -37,12 +37,14 @@ def resolve_latex_citations(latex: str, citation_map: Dict[str, int]) -> str:
 class DocxContentProcessor:
     """Parses markdown content into structured format for DOCX writing."""
 
-    def parse(self, markdown: str, citation_map: Dict[str, int]) -> Dict[str, Any]:
+    def parse(self, markdown: str, citation_map: Dict[str, int], tables_as_images: bool = False) -> Dict[str, Any]:
         """Parse markdown into structured sections for DOCX.
 
         Args:
             markdown: Markdown content to parse
             citation_map: Mapping from citation keys to numbers
+            tables_as_images: Render Markdown tables as images too (as ``tex_table``
+                sections), so every table shares one style with ``{{tex}}`` tables
 
         Returns:
             Document structure with sections and formatting metadata
@@ -224,7 +226,7 @@ class DocxContentProcessor:
 
             # Check for table (starts with |)
             if line.strip().startswith("|"):
-                table_data, next_i = self._parse_table(lines, i)
+                table_data, next_i = self._parse_table(lines, i, citation_map, tables_as_images)
                 if table_data:
                     sections.append(table_data)
                     i = next_i
@@ -715,7 +717,13 @@ class DocxContentProcessor:
             "is_supplementary": is_supplementary,
         }, next_i
 
-    def _parse_table(self, lines: List[str], start_idx: int) -> tuple[Optional[Dict[str, Any]], int]:
+    def _parse_table(
+        self,
+        lines: List[str],
+        start_idx: int,
+        citation_map: Optional[Dict[str, int]] = None,
+        tables_as_images: bool = False,
+    ) -> tuple[Optional[Dict[str, Any]], int]:
         """Parse a markdown table.
 
         Expected format:
@@ -726,9 +734,12 @@ class DocxContentProcessor:
         Args:
             lines: All lines of content
             start_idx: Starting line index (at first |)
+            citation_map: Mapping from citation keys to numbers (for image conversion)
+            tables_as_images: When True, emit a ``tex_table`` (image) section instead of
+                a native Word table
 
         Returns:
-            Tuple of (table dict or None, next line index)
+            Tuple of (table/tex_table dict or None, next line index)
         """
         table_lines = []
         i = start_idx
@@ -774,6 +785,14 @@ class DocxContentProcessor:
                 caption = caption_match.group(3).strip()
                 i += 1  # Move past caption line
 
+        # When every table is rendered as an image (for one consistent style), convert
+        # the Markdown table to LaTeX and emit a tex_table section instead.
+        if tables_as_images:
+            section = self._markdown_table_to_tex_section(table_lines, label, caption, citation_map or {})
+            if section is not None:
+                return section, i
+            # conversion failed -> fall back to a native Word table
+
         return {
             "type": "table",
             "headers": headers,
@@ -781,3 +800,36 @@ class DocxContentProcessor:
             "caption": caption,
             "label": label,
         }, i
+
+    @staticmethod
+    def _strip_docx_markers(text: str) -> str:
+        """Remove DOCX-internal <<XREF>>/<<HIGHLIGHT>> markers, keeping the inner text."""
+        text = re.sub(r"<<XREF:[a-z]+>>(.*?)<</XREF>>", r"\1", text, flags=re.S)
+        text = re.sub(r"<<HIGHLIGHT_[A-Z]+>>(.*?)<</HIGHLIGHT_[A-Z]+>>", r"\1", text, flags=re.S)
+        return text
+
+    def _markdown_table_to_tex_section(
+        self, table_lines: List[str], label: Optional[str], caption: Optional[str], citation_map: Dict[str, int]
+    ) -> Optional[Dict[str, Any]]:
+        """Convert a Markdown table to a ``tex_table`` section (rendered as an image).
+
+        Reuses the PDF-path Markdown->LaTeX converter so the image matches the PDF.
+        Cross-references and citations in cells are already resolved to plain text in the
+        DOCX stream, so only the DOCX-internal markers are stripped before converting.
+        Returns ``None`` if conversion does not yield a tabular (caller falls back).
+        """
+        from ..converters.table_processor import convert_tables_to_latex
+
+        cleaned = self._strip_docx_markers("\n".join(table_lines))
+        try:
+            latex = convert_tables_to_latex(cleaned)
+        except Exception:  # pragma: no cover - defensive, fall back to native table
+            return None
+        if "\\begin{tabular" not in latex:
+            return None
+        latex = resolve_latex_citations(latex, citation_map)  # defensive; cells are usually pre-resolved
+        section: Dict[str, Any] = {"type": "tex_table", "latex": latex}
+        if caption:
+            section["caption_label"] = label
+            section["caption_text"] = caption  # keep markers; the writer formats the caption
+        return section

--- a/src/rxiv_maker/exporters/docx_content_processor.py
+++ b/src/rxiv_maker/exporters/docx_content_processor.py
@@ -9,17 +9,21 @@ from typing import Any, Dict, List, Optional
 
 from ..utils.comment_filter import is_metadata_comment
 
-# Real LaTeX citations only: a backslash immediately followed by "cite{...}".
-# Escaped display forms such as "\textbackslash cite\{x\}" (used in syntax-reference
-# tables) deliberately do not match, so they are left verbatim in the rendered image.
-_CITE_RE = re.compile(r"\\cite\{([^{}]+)\}")
+# Numeric-style LaTeX citation commands (natbib/biblatex), each a backslash
+# immediately followed by the command and "{...}". Author/year-only forms
+# (\citeauthor, \citeyear, \citetitle) are deliberately excluded - they do not
+# resolve to a number. Escaped display forms such as "\textbackslash cite\{x\}"
+# (used in syntax-reference tables) do not match, so they stay verbatim.
+_CITE_RE = re.compile(r"\\(?:citep|citet|citenum|autocite|parencite|textcite|cite)\*?\{([^{}]+)\}")
 
 
 def resolve_latex_citations(latex: str, citation_map: Dict[str, int]) -> str:
-    r"""Replace ``\cite{key,...}`` with the DOCX citation numbers, e.g. ``[7, 12]``.
+    r"""Replace numeric citation commands (``\cite``/``\citep``/``\citet``/...) with numbers.
 
+    Resolves each command to the DOCX citation numbers, e.g. ``[7, 12]``.
     Keys present in ``citation_map`` become their number; unknown keys are kept
-    verbatim so attribution is never silently dropped.
+    verbatim so attribution is never silently dropped. The standalone table render
+    has no bibliography, so an unconverted command would otherwise print ``[?]``.
     """
 
     def _sub(match: "re.Match[str]") -> str:

--- a/src/rxiv_maker/exporters/docx_content_processor.py
+++ b/src/rxiv_maker/exporters/docx_content_processor.py
@@ -86,7 +86,16 @@ class DocxContentProcessor:
                     i += 1
                 i += 1  # skip the <<TEX_TABLE_END>> line
                 latex = resolve_latex_citations("\n".join(tex_lines).strip(), citation_map)
-                sections.append({"type": "tex_table", "latex": latex})
+                section = {"type": "tex_table", "latex": latex}
+                # A caption authored just above the {{tex}} block (the common
+                # %{#stable:label} convention) is attached here so the writer renders
+                # it BELOW the image - matching Markdown-table/PDF caption placement and
+                # keeping caption and image on the same page.
+                if sections and sections[-1].get("type") == "table_caption":
+                    cap = sections.pop()
+                    section["caption_label"] = cap["label"]
+                    section["caption_text"] = cap["caption"]
+                sections.append(section)
                 continue
 
             # Parse HTML/markdown comments (single-line and multi-line)

--- a/src/rxiv_maker/exporters/docx_exporter.py
+++ b/src/rxiv_maker/exporters/docx_exporter.py
@@ -35,6 +35,7 @@ class DocxExporter:
         include_footnotes: bool = True,
         content_mode: str = "full",
         output_suffix: str | None = None,
+        tables_as_images: bool = False,
     ):
         """Initialize DOCX exporter.
 
@@ -44,6 +45,8 @@ class DocxExporter:
             include_footnotes: Whether to include DOI footnotes
             content_mode: Content to export: "full", "main", or "si"
             output_suffix: Optional suffix to append before .docx
+            tables_as_images: Render Markdown tables as images too (like {{tex}} tables),
+                so every table shares one style. Overrides the docx.tables_as_images config.
         """
         if content_mode not in {"full", "main", "si"}:
             raise ValueError("content_mode must be one of: full, main, si")
@@ -67,6 +70,9 @@ class DocxExporter:
         self.figures_at_end = docx_config.get("figures_at_end", False)  # Default to False (inline figures)
         self.hide_highlighting = docx_config.get("hide_highlighting", False)  # Default to False (show highlights)
         self.hide_comments = docx_config.get("hide_comments", False)  # Default to False (include comments)
+        # Render every table as an image (Markdown tables too) so they don't diverge in
+        # style from {{tex}} tables. CLI flag overrides the config; default off.
+        self.tables_as_images = tables_as_images or docx_config.get("tables_as_images", False)
 
         # Components
         self.citation_mapper = CitationMapper()
@@ -263,7 +269,9 @@ class DocxExporter:
         )
 
         # Step 6: Convert content to DOCX structure
-        doc_structure = self.content_processor.parse(markdown_with_numbers, citation_map)
+        doc_structure = self.content_processor.parse(
+            markdown_with_numbers, citation_map, tables_as_images=self.tables_as_images
+        )
         logger.debug(f"Parsed {len(doc_structure['sections'])} sections")
 
         # Step 6.5: Get metadata for title page

--- a/src/rxiv_maker/exporters/docx_writer.py
+++ b/src/rxiv_maker/exporters/docx_writer.py
@@ -1137,17 +1137,29 @@ class DocxWriter:
         document never silently loses the table.
         """
         latex = section.get("latex", "")
+        caption_text = section.get("caption_text")
+        # Keep the image with its caption below when a caption is attached.
+        keep_with_caption = bool(caption_text)
         image_path = self._render_tex_table_to_image(latex)
+        embedded = False
         if image_path is not None:
             try:
-                self._embed_table_image(doc, image_path)
-                return
+                self._embed_table_image(doc, image_path, keep_with_next=keep_with_caption)
+                embedded = True
             except Exception as e:  # pragma: no cover - defensive
                 logger.warning(f"Failed to embed tex-table image: {e}")
-        self._add_tex_table_placeholder(doc)
+        if not embedded:
+            self._add_tex_table_placeholder(doc)
+        # Caption goes below the table (matches Markdown-table and PDF placement).
+        if caption_text:
+            self._render_table_caption(doc, section.get("caption_label"), caption_text)
 
-    def _embed_table_image(self, doc: Document, image_path: Path):
-        """Embed a rendered table image, centered and fit to the page box."""
+    def _embed_table_image(self, doc: Document, image_path: Path, keep_with_next: bool = False):
+        """Embed a rendered table image, centered and fit to the page box.
+
+        When ``keep_with_next`` is set, the image paragraph is bound to the following
+        paragraph (its caption) so Word does not split them across a page break.
+        """
         from PIL import Image as PILImage
 
         sec = doc.sections[-1]
@@ -1158,6 +1170,8 @@ class DocxWriter:
 
         para = doc.add_paragraph()
         para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        if keep_with_next:
+            para.paragraph_format.keep_with_next = True
         run = para.add_run()
         # Wide tables constrain by width; unusually tall ones constrain by height.
         if (w / h) >= (avail_w / avail_h):

--- a/src/rxiv_maker/exporters/docx_writer.py
+++ b/src/rxiv_maker/exporters/docx_writer.py
@@ -5,6 +5,8 @@ writing structured content with formatting, citations, and references.
 """
 
 import base64
+import contextlib
+import re
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -21,6 +23,50 @@ from ..utils.author_affiliation_processor import AuthorAffiliationProcessor
 from ..utils.docx_helpers import convert_pdf_to_image
 
 logger = get_logger()
+
+_SIZE_CMD = r"\\(?:tiny|scriptsize|footnotesize|small|normalsize|large|Large|huge)"
+
+
+def prepare_table_latex(content: str) -> Optional[str]:
+    r"""Normalise a ``{{tex}}`` table block into a standalone-renderable tabular.
+
+    Strips float wrappers (``stable``/``table``), captions/labels/captionsetup, and
+    rewrites a ``longtable`` to a plain ``tabular`` keeping a single header (the
+    repeated-head/foot machinery is removed). A font-size command sitting just
+    before the tabular (e.g. ``\small``) is preserved.
+
+    Returns the prepared LaTeX, or ``None`` if no ``tabular``/``tabularx`` survives.
+    """
+    s = content
+
+    # Drop caption/label/captionsetup (single level of nested braces tolerated).
+    s = re.sub(r"\\caption\*?\{(?:[^{}]|\{[^{}]*\})*\}", "", s)
+    s = re.sub(r"\\captionsetup(?:\[[^\]]*\])?\{[^{}]*\}", "", s)
+    s = re.sub(r"\\label\{[^{}]*\}", "", s)
+
+    # longtable -> tabular: remove repeated header/footer machinery, keep first head.
+    if "\\begin{longtable}" in s:
+        s = re.sub(r"\\endfirsthead.*?\\endhead", "", s, flags=re.S)
+        s = re.sub(r"\\endfoot.*?\\endlastfoot", "", s, flags=re.S)
+        s = re.sub(r"\\(?:endhead|endfirsthead|endfoot|endlastfoot)\b", "", s)
+        s = s.replace("\\begin{longtable}", "\\begin{tabular}").replace("\\end{longtable}", "\\end{tabular}")
+
+    # Extract the outermost tabular(*)/tabularx environment.
+    m = re.search(r"\\begin\{(tabular\*?|tabularx)\}", s)
+    if not m:
+        return None
+    env = m.group(1)
+    start = m.start()
+    end_token = "\\end{" + env + "}"
+    end = s.rfind(end_token)
+    if end == -1:
+        return None
+    table = s[start : end + len(end_token)]
+
+    # Preserve a font-size command that preceded the tabular.
+    sizes = re.findall(_SIZE_CMD, s[:start])
+    prefix = sizes[-1] + "\n" if sizes else ""
+    return prefix + table
 
 
 class DocxWriter:
@@ -393,6 +439,10 @@ class DocxWriter:
             self._add_figure(doc, section)
         elif section_type == "table":
             self._add_table(doc, section)
+        elif section_type == "tex_table":
+            self._add_tex_table(doc, section)
+        elif section_type == "table_caption":
+            self._add_table_caption(doc, section)
         elif section_type == "equation":
             self._add_equation(doc, section)
         elif section_type == "page_break":
@@ -892,65 +942,87 @@ class DocxWriter:
         caption = section.get("caption")
         label = section.get("label")
         if caption:
-            caption_para = doc.add_paragraph()
-            caption_para.alignment = WD_ALIGN_PARAGRAPH.LEFT
-            # Add small space before caption to separate from table
-            caption_para.paragraph_format.space_before = Pt(3)
-
-            # Determine table number from label using table_map
-            if label and label.startswith("stable:"):
-                # Extract label name (e.g., "stable:parameters" -> "parameters")
-                label_name = label.split(":", 1)[1] if ":" in label else label
-                # Look up number in table_map
-                table_num = self.table_map.get(label_name)
-                if table_num:
-                    run = caption_para.add_run(f"Supp. Table S{table_num}. ")
-                else:
-                    # Fallback if label not in map
-                    run = caption_para.add_run("Supp. Table: ")
-                run.bold = True
-                run.font.size = Pt(8)
-            elif label and label.startswith("table:"):
-                # Extract label name for main tables
-                label_name = label.split(":", 1)[1] if ":" in label else label
-                # Look up number in table_map (though main tables may not be in map)
-                table_num = self.table_map.get(label_name)
-                if table_num:
-                    run = caption_para.add_run(f"Table {table_num}. ")
-                else:
-                    run = caption_para.add_run("Table: ")
-                run.bold = True
-                run.font.size = Pt(8)
-
-            # Parse and add caption with inline formatting
-            caption_runs = processor._parse_inline_formatting(caption, {})
-            for run_data in caption_runs:
-                if run_data["type"] == "text":
-                    text = run_data["text"]
-                    run = caption_para.add_run(text)
-                    run.font.size = Pt(8)
-                    if run_data.get("bold"):
-                        run.bold = True
-                    if run_data.get("italic"):
-                        run.italic = True
-                    if run_data.get("underline"):
-                        run.underline = True
-                    if run_data.get("subscript"):
-                        run.font.subscript = True
-                    if run_data.get("superscript"):
-                        run.font.superscript = True
-                    if run_data.get("code"):
-                        run.font.name = "Courier New"
-                    if run_data.get("xref"):
-                        # Use color based on xref type
-                        xref_type = run_data.get("xref_type", "cite")
-                        self._apply_highlight(run, self.get_xref_color(xref_type))
-
-            # Add spacing after table (reduced from 12 to 6 for compactness)
-            caption_para.paragraph_format.space_after = Pt(6)
+            self._render_table_caption(doc, label, caption)
 
         # Add spacing after table
         doc.add_paragraph()
+
+    def _add_table_caption(self, doc: Document, section: Dict[str, Any]):
+        """Render a standalone table-caption line (``{#stable:label} ...``).
+
+        These appear when a caption precedes a ``{{tex}}`` table (or is otherwise
+        not attached to a Markdown table), so it is not consumed by ``_parse_table``.
+        Without this the raw ``{#stable:label}`` / ``%{#stable:label}`` marker leaks
+        into the Word output.
+        """
+        self._render_table_caption(doc, section.get("label"), section.get("caption", ""))
+
+    def _render_table_caption(self, doc: Document, label: Optional[str], caption: str):
+        """Render a ``Supp. Table SN. <caption>`` paragraph.
+
+        Shared by Markdown tables and standalone caption lines. The number is looked
+        up in ``self.table_map``.
+        """
+        from rxiv_maker.exporters.docx_content_processor import DocxContentProcessor
+
+        processor = DocxContentProcessor()
+
+        caption_para = doc.add_paragraph()
+        caption_para.alignment = WD_ALIGN_PARAGRAPH.LEFT
+        # Add small space before caption to separate from table
+        caption_para.paragraph_format.space_before = Pt(3)
+
+        # Determine table number from label using table_map
+        if label and label.startswith("stable:"):
+            # Extract label name (e.g., "stable:parameters" -> "parameters")
+            label_name = label.split(":", 1)[1] if ":" in label else label
+            # Look up number in table_map
+            table_num = self.table_map.get(label_name)
+            if table_num:
+                run = caption_para.add_run(f"Supp. Table S{table_num}. ")
+            else:
+                # Fallback if label not in map
+                run = caption_para.add_run("Supp. Table: ")
+            run.bold = True
+            run.font.size = Pt(8)
+        elif label and label.startswith("table:"):
+            # Extract label name for main tables
+            label_name = label.split(":", 1)[1] if ":" in label else label
+            # Look up number in table_map (though main tables may not be in map)
+            table_num = self.table_map.get(label_name)
+            if table_num:
+                run = caption_para.add_run(f"Table {table_num}. ")
+            else:
+                run = caption_para.add_run("Table: ")
+            run.bold = True
+            run.font.size = Pt(8)
+
+        # Parse and add caption with inline formatting
+        caption_runs = processor._parse_inline_formatting(caption, {})
+        for run_data in caption_runs:
+            if run_data["type"] == "text":
+                text = run_data["text"]
+                run = caption_para.add_run(text)
+                run.font.size = Pt(8)
+                if run_data.get("bold"):
+                    run.bold = True
+                if run_data.get("italic"):
+                    run.italic = True
+                if run_data.get("underline"):
+                    run.underline = True
+                if run_data.get("subscript"):
+                    run.font.subscript = True
+                if run_data.get("superscript"):
+                    run.font.superscript = True
+                if run_data.get("code"):
+                    run.font.name = "Courier New"
+                if run_data.get("xref"):
+                    # Use color based on xref type
+                    xref_type = run_data.get("xref_type", "cite")
+                    self._apply_highlight(run, self.get_xref_color(xref_type))
+
+        # Add spacing after table (reduced from 12 to 6 for compactness)
+        caption_para.paragraph_format.space_after = Pt(6)
 
     def _add_inline_equation(self, paragraph, latex_content: str):
         """Add inline equation to paragraph as Office Math.
@@ -1058,6 +1130,134 @@ class DocxWriter:
         # Add spacing after equation
         para.paragraph_format.space_after = Pt(12)
 
+    def _add_tex_table(self, doc: Document, section: Dict[str, Any]):
+        """Render a preserved {{tex}} table to an image and embed it.
+
+        Falls back to a textual placeholder if the LaTeX cannot be rendered, so the
+        document never silently loses the table.
+        """
+        latex = section.get("latex", "")
+        image_path = self._render_tex_table_to_image(latex)
+        if image_path is not None:
+            try:
+                self._embed_table_image(doc, image_path)
+                return
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(f"Failed to embed tex-table image: {e}")
+        self._add_tex_table_placeholder(doc)
+
+    def _embed_table_image(self, doc: Document, image_path: Path):
+        """Embed a rendered table image, centered and fit to the page box."""
+        from PIL import Image as PILImage
+
+        sec = doc.sections[-1]
+        avail_w = sec.page_width - sec.left_margin - sec.right_margin
+        avail_h = sec.page_height - sec.top_margin - sec.bottom_margin
+        with PILImage.open(str(image_path)) as img:
+            w, h = img.size
+
+        para = doc.add_paragraph()
+        para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        run = para.add_run()
+        # Wide tables constrain by width; unusually tall ones constrain by height.
+        if (w / h) >= (avail_w / avail_h):
+            run.add_picture(str(image_path), width=avail_w)
+        else:
+            run.add_picture(str(image_path), height=avail_h)
+        logger.debug(f"Embedded tex-table image: {image_path} ({w}x{h})")
+
+    def _add_tex_table_placeholder(self, doc: Document):
+        """Fallback note when a {{tex}} table could not be rendered to an image."""
+        para = doc.add_paragraph()
+        para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        run = para.add_run("[LaTeX table - please refer to the PDF version for proper formatting]")
+        run.italic = True
+        with contextlib.suppress(Exception):  # highlight is best-effort
+            run.font.highlight_color = WD_COLOR_INDEX.YELLOW
+
+    def _render_tex_table_to_image(self, latex: str) -> Optional[Path]:
+        """Render a {{tex}} table to a high-resolution PNG via pdflatex + pdftoppm.
+
+        Returns the PNG path, or None if no tabular is present or rendering fails.
+        Results are cached by content hash; intermediates are cleaned up.
+        """
+        import hashlib
+        import subprocess
+        import tempfile
+
+        table_body = prepare_table_latex(latex)
+        if not table_body:
+            logger.warning("No tabular found in {{tex}} table block; using placeholder.")
+            return None
+
+        tbl_hash = hashlib.md5(table_body.encode(), usedforsecurity=False).hexdigest()[:10]
+        temp_dir = Path(tempfile.gettempdir()) / "rxiv_tex_tables"
+        temp_dir.mkdir(exist_ok=True)
+        output_png = temp_dir / f"tbl_{tbl_hash}.png"
+        if output_png.exists():
+            logger.debug(f"Using cached tex-table image: {output_png}")
+            return output_png
+
+        # \textwidth is set wide so p{0.30\textwidth}-style fractional columns,
+        # which assume a full text block, resolve to sensible widths in standalone.
+        latex_template = (
+            r"""\documentclass[border=8pt]{standalone}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{array}
+\usepackage{booktabs}
+\usepackage{multirow}
+\usepackage{makecell}
+\usepackage{tabularx}
+\usepackage{graphicx}
+\usepackage[table]{xcolor}
+\usepackage{amsmath,amssymb}
+\usepackage{textcomp}
+\usepackage{ragged2e}
+\usepackage[hidelinks]{hyperref}
+\setlength{\textwidth}{20cm}
+\begin{document}
+"""
+            + table_body
+            + "\n\\end{document}\n"
+        )
+
+        tex_file = temp_dir / f"tbl_{tbl_hash}.tex"
+        tex_file.write_text(latex_template)
+        try:
+            result = subprocess.run(
+                ["pdflatex", "-interaction=nonstopmode", "-output-directory", str(temp_dir), str(tex_file)],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            pdf_file = temp_dir / f"tbl_{tbl_hash}.pdf"
+            if not pdf_file.exists():
+                logger.warning(f"pdflatex failed for {{tex}} table (rc={result.returncode}); using placeholder.")
+                logger.debug(f"pdflatex tail: {result.stdout[-1500:]}")
+                return None
+
+            result = subprocess.run(
+                ["pdftoppm", "-png", "-singlefile", "-r", "300", str(pdf_file), str(temp_dir / f"tbl_{tbl_hash}")],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode != 0 or not output_png.exists():
+                logger.warning(f"pdftoppm failed for {{tex}} table: {result.stderr}")
+                return None
+            logger.debug(f"Rendered tex-table image: {output_png}")
+            return output_png
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            logger.warning(f"tex-table rendering unavailable ({e}); using placeholder.")
+            return None
+        finally:
+            for ext in (".tex", ".pdf", ".aux", ".log"):
+                stale = temp_dir / f"tbl_{tbl_hash}{ext}"
+                if stale.exists():
+                    with contextlib.suppress(Exception):
+                        stale.unlink()
+
     def _render_equation_to_image(self, latex_content: str) -> Optional[Path]:
         """Render LaTeX equation to PNG image.
 
@@ -1073,7 +1273,7 @@ class DocxWriter:
         from pathlib import Path
 
         # Create a hash of the equation content for caching
-        eq_hash = hashlib.md5(latex_content.encode()).hexdigest()[:8]
+        eq_hash = hashlib.md5(latex_content.encode(), usedforsecurity=False).hexdigest()[:8]
 
         # Use temp directory for equation images
         temp_dir = Path(tempfile.gettempdir()) / "rxiv_equations"
@@ -1157,10 +1357,8 @@ class DocxWriter:
             for ext in [".tex", ".pdf", ".aux", ".log"]:
                 temp_file = temp_dir / f"eq_{eq_hash}{ext}"
                 if temp_file.exists():
-                    try:
+                    with contextlib.suppress(Exception):
                         temp_file.unlink()
-                    except Exception:
-                        pass
 
     def _render_latex_formatted(self, paragraph, latex_content: str):
         """Render LaTeX equation with formatted subscripts and superscripts.

--- a/src/rxiv_maker/processors/markdown_preprocessor.py
+++ b/src/rxiv_maker/processors/markdown_preprocessor.py
@@ -181,15 +181,11 @@ class MarkdownPreprocessor:
             # Check if this is a large table/complex structure
             is_table = "\\begin{" in tex_content and ("table" in tex_content or "longtable" in tex_content)
 
-            # For tables, provide a more informative message with yellow highlighting
+            # For tables, preserve the raw LaTeX between sentinels so the DOCX
+            # writer can render it to an image (see docx_writer._add_tex_table).
+            # The writer falls back to a textual placeholder if rendering fails.
             if is_table:
-                note = (
-                    "\n\n---\n\n"
-                    "<<HIGHLIGHT_YELLOW>>**[LaTeX Table - Please refer to the PDF version for proper table formatting]**<</HIGHLIGHT_YELLOW>>\n\n"
-                    "<<HIGHLIGHT_YELLOW>>_This section contains a complex LaTeX table that cannot be displayed in Word format. "
-                    "The table shows the Markdown-to-LaTeX syntax reference with formatting examples._<</HIGHLIGHT_YELLOW>>\n\n"
-                    "---\n\n"
-                )
+                return f"\n\n<<TEX_TABLE_START>>\n{tex_content}\n<<TEX_TABLE_END>>\n\n"
             else:
                 # For other LaTeX blocks, show a compact version
                 # Truncate very long content

--- a/src/rxiv_maker/utils/label_extractor.py
+++ b/src/rxiv_maker/utils/label_extractor.py
@@ -71,8 +71,9 @@ class LabelExtractor:
     def extract_supplementary_table_labels(content: str) -> Dict[str, int]:
         r"""Extract supplementary table labels and create number mapping.
 
-        Finds both markdown format {#stable:label} and LaTeX format \\label{stable:label}.
-        Prefers LaTeX labels if both are present (matches PDF behavior).
+        Finds both markdown format {#stable:label} and LaTeX format \\label{stable:label},
+        numbering every label in document order (deduplicated). Mixed documents - markdown
+        tables alongside a {{tex}} table carrying its own \\label - are numbered correctly.
 
         Args:
             content: Markdown/LaTeX content to scan
@@ -87,16 +88,18 @@ class LabelExtractor:
             {'params': 1, 'results': 2}
         r
         """
-        # Extract both markdown and LaTeX formats
-        markdown_labels = re.findall(r"\{#stable:([\w-]+)\}", content)
-        latex_labels = re.findall(r"\\label\{stable:([\w-]+)\}", content)
-
-        # Prefer LaTeX labels (matches PDF behavior), fall back to markdown
-        table_labels = latex_labels if latex_labels else markdown_labels
-
-        # Remove duplicates while preserving order
+        # Number every supplementary-table label in document order, accepting both the
+        # markdown form ({#stable:label}) and the LaTeX form (\label{stable:label}).
+        # A manuscript may mix the two - e.g. markdown tables alongside a {{tex}} table
+        # that carries its own \label - so we must not pick one form to the exclusion of
+        # the other (an earlier "prefer LaTeX, else markdown" rule misnumbered such
+        # mixed documents). Deduplication keeps the first occurrence, so a table labelled
+        # in both forms is counted once, at the position it first appears.
+        labels = [
+            m.group(1) or m.group(2) for m in re.finditer(r"\\label\{stable:([\w-]+)\}|\{#stable:([\w-]+)\}", content)
+        ]
         seen = set()
-        unique_labels = [label for label in table_labels if not (label in seen or seen.add(label))]
+        unique_labels = [label for label in labels if not (label in seen or seen.add(label))]
 
         return {label: i + 1 for i, label in enumerate(unique_labels)}
 

--- a/tests/integration/test_docx_tex_table_render.py
+++ b/tests/integration/test_docx_tex_table_render.py
@@ -1,0 +1,34 @@
+"""Integration test for rendering a {{tex}} table to a PNG image.
+
+Exercises the real ``prepare_table_latex`` -> pdflatex -> pdftoppm pipeline.
+The function name contains "latex" so conftest auto-marks it ``requires_latex``
+(it skips cleanly where no LaTeX toolchain is installed).
+"""
+
+from rxiv_maker.exporters.docx_writer import DocxWriter
+
+SIMPLE_STABLE = (
+    "\\begin{stable}[h!]\n"
+    "\\small\n"
+    "\\begin{tabular}{|l|l|}\n"
+    "\\hline\n"
+    "\\textbf{Col A} & \\textbf{Col B} \\\\\n"
+    "\\hline\n"
+    "alpha & beta \\\\\n"
+    "\\hline\n"
+    "\\end{tabular}\n"
+    "\\caption{Demo.}\n"
+    "\\label{stable:demo}\n"
+    "\\end{stable}"
+)
+
+
+def test_latex_table_renders_to_png():
+    writer = DocxWriter.__new__(DocxWriter)  # only the render method is needed
+    png = DocxWriter._render_tex_table_to_image(writer, SIMPLE_STABLE)
+    assert png is not None, "expected a rendered PNG from a valid tabular"
+    assert png.exists() and png.stat().st_size > 0
+    from PIL import Image
+
+    width, height = Image.open(str(png)).size
+    assert width > 50 and height > 20

--- a/tests/unit/test_docx_tex_tables.py
+++ b/tests/unit/test_docx_tex_tables.py
@@ -1,0 +1,174 @@
+"""Unit tests for rendering {{tex}} tables as images in DOCX export.
+
+Covers the three pure layers of the feature:
+  * the preprocessor emitting a recoverable sentinel (not a placeholder) for tables,
+  * the content processor turning that sentinel into a ``tex_table`` section with
+    its ``\\cite`` commands resolved to the DOCX citation numbers, and
+  * the LaTeX-preparation helper that normalises a float/longtable down to a
+    standalone-renderable ``tabular``.
+
+The actual pdflatex -> png render is exercised in the integration suite (it needs
+a LaTeX toolchain) and against the real manuscripts.
+"""
+
+from rxiv_maker.exporters.docx_content_processor import (
+    DocxContentProcessor,
+    resolve_latex_citations,
+)
+from rxiv_maker.exporters.docx_writer import prepare_table_latex
+from rxiv_maker.processors.markdown_preprocessor import MarkdownPreprocessor
+from rxiv_maker.utils.label_extractor import LabelExtractor
+
+STABLE_BLOCK = """Intro paragraph.
+
+{{tex:
+\\begin{stable}[h!]
+\\small
+\\begin{tabular}{|l|l|}
+\\hline
+\\textbf{Feature} & \\textbf{Tool} \\\\
+\\hline
+Input & PDB~\\cite{smith2020} \\\\
+\\hline
+\\end{tabular}
+\\caption{\\textbf{A comparison.}}
+\\label{stable:comparison}
+\\end{stable}
+}}
+
+Outro paragraph.
+"""
+
+LONGTABLE_BLOCK = """{{tex:
+\\small
+\\begin{longtable}{|p{0.3\\textwidth}|p{0.3\\textwidth}|}
+\\hline
+\\textbf{A} & \\textbf{B} \\\\
+\\hline
+\\endfirsthead
+\\hline
+\\textbf{A} & \\textbf{B} \\\\
+\\hline
+\\endhead
+one & two \\\\
+\\hline
+\\end{longtable}
+}}
+"""
+
+INLINE_TEX = "See `{{tex:\\alpha}}` inline.\n\nText with {{tex:\\alpha}} mention.\n"
+
+
+class TestStripTexBlocksEmitsSentinel:
+    def test_table_block_becomes_sentinel_not_placeholder(self):
+        out = MarkdownPreprocessor().process(STABLE_BLOCK, target_format="docx")
+        assert "<<TEX_TABLE_START>>" in out
+        assert "<<TEX_TABLE_END>>" in out
+        # the raw tabular survives for later rendering
+        assert "\\begin{tabular}" in out
+        # the old placeholder is gone
+        assert "refer to the PDF version" not in out
+
+    def test_longtable_block_becomes_sentinel(self):
+        out = MarkdownPreprocessor().process(LONGTABLE_BLOCK, target_format="docx")
+        assert "<<TEX_TABLE_START>>" in out
+        assert "\\begin{longtable}" in out
+
+    def test_inline_block_unchanged(self):
+        # An inline mention must not be treated as a table.
+        out = MarkdownPreprocessor().process(INLINE_TEX, target_format="docx")
+        assert "<<TEX_TABLE_START>>" not in out
+
+
+class TestResolveLatexCitations:
+    def test_single_cite_to_number(self):
+        assert resolve_latex_citations("PDB~\\cite{smith2020}", {"smith2020": 7}) == "PDB~[7]"
+
+    def test_multi_key_cite_to_numbers(self):
+        out = resolve_latex_citations("\\cite{a,b}", {"a": 3, "b": 9})
+        assert out == "[3, 9]"
+
+    def test_unknown_key_kept_verbatim(self):
+        out = resolve_latex_citations("\\cite{ghost}", {"smith2020": 7})
+        assert "ghost" in out and "\\cite" not in out
+
+    def test_escaped_cite_is_not_touched(self):
+        # The syntax-reference table shows "\textbackslash cite\{x\}" literally.
+        text = "\\textbackslash cite\\{mycitation\\}"
+        assert resolve_latex_citations(text, {"mycitation": 1}) == text
+
+
+class TestPrepareTableLatex:
+    def test_strips_float_and_caption(self):
+        raw = STABLE_BLOCK.split("{{tex:")[1].split("}}")[0].strip()
+        out = prepare_table_latex(raw)
+        assert out is not None
+        assert "\\begin{tabular}" in out and "\\end{tabular}" in out
+        assert "\\begin{stable}" not in out
+        assert "\\caption" not in out and "\\label" not in out
+        # size command preserved
+        assert "\\small" in out
+
+    def test_longtable_converted_to_tabular(self):
+        raw = LONGTABLE_BLOCK.split("{{tex:")[1].split("}}")[0].strip()
+        out = prepare_table_latex(raw)
+        assert out is not None
+        assert "\\begin{tabular}" in out
+        assert "longtable" not in out
+        # repeated-header machinery removed
+        assert "\\endhead" not in out and "\\endfirsthead" not in out
+        # exactly one header row kept
+        assert out.count("\\textbf{A}") == 1
+
+    def test_plain_prose_yields_none(self):
+        assert prepare_table_latex("\\textbf{just text, no table}") is None
+
+
+class TestStandaloneTableCaption:
+    def test_percent_caption_becomes_section(self):
+        # %{#stable:label} caption (the % hides it from LaTeX) must not leak.
+        parsed = DocxContentProcessor().parse("%{#stable:comparison} **Comparison of tools.**\n", {})
+        caps = [s for s in parsed["sections"] if s["type"] == "table_caption"]
+        assert len(caps) == 1
+        assert caps[0]["label"] == "stable:comparison"
+        assert "Comparison of tools" in caps[0]["caption"]
+
+    def test_plain_caption_becomes_section(self):
+        parsed = DocxContentProcessor().parse("{#stable:vm_params} **Optical parameters.**\n", {})
+        caps = [s for s in parsed["sections"] if s["type"] == "table_caption"]
+        assert len(caps) == 1 and caps[0]["label"] == "stable:vm_params"
+
+    def test_caption_below_md_table_not_double_emitted(self):
+        md = "| A | B |\n|---|---|\n| 1 | 2 |\n\n{#stable:t} Caption text.\n"
+        parsed = DocxContentProcessor().parse(md, {})
+        tables = [s for s in parsed["sections"] if s["type"] == "table"]
+        caps = [s for s in parsed["sections"] if s["type"] == "table_caption"]
+        # The caption is consumed by the table, not emitted as a standalone section.
+        assert len(tables) == 1 and tables[0]["caption"] == "Caption text."
+        assert len(caps) == 0
+
+
+class TestTableLabelMerge:
+    def test_mixed_label_forms_numbered_in_order(self):
+        content = "{#stable:a} x\n{#stable:b} y\n\\label{stable:c}\n"
+        assert LabelExtractor().extract_supplementary_table_labels(content) == {"a": 1, "b": 2, "c": 3}
+
+    def test_same_label_in_both_forms_deduped(self):
+        content = "{#stable:comp} x\n\\label{stable:comp}\n"
+        assert LabelExtractor().extract_supplementary_table_labels(content) == {"comp": 1}
+
+
+class TestContentProcessorTexTableSection:
+    def test_sentinel_becomes_table_section_with_numbers(self):
+        preprocessed = MarkdownPreprocessor().process(STABLE_BLOCK, target_format="docx")
+        parsed = DocxContentProcessor().parse(preprocessed, {"smith2020": 7})
+        tex_tables = [s for s in parsed["sections"] if s["type"] == "tex_table"]
+        assert len(tex_tables) == 1
+        latex = tex_tables[0]["latex"]
+        assert "[7]" in latex
+        assert "\\cite" not in latex
+        # surrounding paragraphs still present, table sits between them
+        types = [s["type"] for s in parsed["sections"]]
+        ti = types.index("tex_table")
+        assert "paragraph" in types[:ti]  # intro before
+        assert "paragraph" in types[ti + 1 :]  # outro after

--- a/tests/unit/test_docx_tex_tables.py
+++ b/tests/unit/test_docx_tex_tables.py
@@ -97,6 +97,19 @@ class TestResolveLatexCitations:
         text = "\\textbackslash cite\\{mycitation\\}"
         assert resolve_latex_citations(text, {"mycitation": 1}) == text
 
+    def test_cite_family_commands_resolved(self):
+        cmap = {"a": 4, "b": 9}
+        assert resolve_latex_citations("\\citep{a}", cmap) == "[4]"
+        assert resolve_latex_citations("\\citet{a,b}", cmap) == "[4, 9]"
+        assert resolve_latex_citations("\\autocite{b}", cmap) == "[9]"
+        assert resolve_latex_citations("\\citep*{a}", cmap) == "[4]"
+
+    def test_nonnumeric_cite_kept(self):
+        # \citeauthor / \citeyear do not resolve to a number; leave them verbatim.
+        cmap = {"a": 4}
+        assert resolve_latex_citations("\\citeauthor{a}", cmap) == "\\citeauthor{a}"
+        assert resolve_latex_citations("\\citeyear{a}", cmap) == "\\citeyear{a}"
+
 
 class TestPrepareTableLatex:
     def test_strips_float_and_caption(self):

--- a/tests/unit/test_docx_tex_tables.py
+++ b/tests/unit/test_docx_tex_tables.py
@@ -138,6 +138,23 @@ class TestStandaloneTableCaption:
         caps = [s for s in parsed["sections"] if s["type"] == "table_caption"]
         assert len(caps) == 1 and caps[0]["label"] == "stable:vm_params"
 
+    def test_caption_above_table_attaches_below(self):
+        # A %{#stable:x} caption authored above a {{tex}} block is attached to the
+        # tex_table (rendered below the image), not left as a standalone section.
+        md = (
+            "%{#stable:comparison} **Comparison of tools.**\n\n"
+            "{{tex:\n\\begin{stable}[h!]\n\\begin{tabular}{|l|l|}\n\\hline\n"
+            "A & B \\\\\n\\hline\n\\end{tabular}\n\\end{stable}\n}}\n"
+        )
+        pre = MarkdownPreprocessor().process(md, target_format="docx")
+        parsed = DocxContentProcessor().parse(pre, {})
+        tex = [s for s in parsed["sections"] if s["type"] == "tex_table"]
+        caps = [s for s in parsed["sections"] if s["type"] == "table_caption"]
+        assert len(tex) == 1
+        assert tex[0]["caption_label"] == "stable:comparison"
+        assert "Comparison of tools" in tex[0]["caption_text"]
+        assert len(caps) == 0  # attached, not left standalone
+
     def test_caption_below_md_table_not_double_emitted(self):
         md = "| A | B |\n|---|---|\n| 1 | 2 |\n\n{#stable:t} Caption text.\n"
         parsed = DocxContentProcessor().parse(md, {})

--- a/tests/unit/test_docx_tex_tables.py
+++ b/tests/unit/test_docx_tex_tables.py
@@ -188,6 +188,30 @@ class TestTableLabelMerge:
         assert LabelExtractor().extract_supplementary_table_labels(content) == {"comp": 1}
 
 
+class TestTablesAsImages:
+    MD = "| **A** | B |\n|---|---|\n| 1 | x |\n\n{#stable:demo} **Demo caption.**\n"
+
+    def test_markdown_table_becomes_image_when_enabled(self):
+        parsed = DocxContentProcessor().parse(self.MD, {}, tables_as_images=True)
+        types = [s["type"] for s in parsed["sections"]]
+        assert "tex_table" in types and "table" not in types
+        tex = next(s for s in parsed["sections"] if s["type"] == "tex_table")
+        assert "\\begin{tabular" in tex["latex"]
+        assert tex["caption_label"] == "stable:demo"
+        assert tex["caption_text"] == "**Demo caption.**"
+
+    def test_markdown_table_stays_native_when_disabled(self):
+        parsed = DocxContentProcessor().parse(self.MD, {})
+        assert [s["type"] for s in parsed["sections"]] == ["table"]
+
+    def test_docx_markers_stripped_before_conversion(self):
+        md = "| A | B |\n|---|---|\n| <<XREF:sfig>>Supp. Fig. 3<</XREF>> | 2 |\n"
+        parsed = DocxContentProcessor().parse(md, {}, tables_as_images=True)
+        tex = next(s for s in parsed["sections"] if s["type"] == "tex_table")
+        assert "<<XREF" not in tex["latex"]  # marker stripped, not leaked into the image
+        assert "Supp. Fig. 3" in tex["latex"]
+
+
 class TestContentProcessorTexTableSection:
     def test_sentinel_becomes_table_section_with_numbers(self):
         preprocessed = MarkdownPreprocessor().process(STABLE_BLOCK, target_format="docx")


### PR DESCRIPTION
## Summary

Raw `{{tex:...}}` tables were dropped from DOCX export and replaced by a *"refer to the PDF version"* placeholder, because the writer can't execute LaTeX into Word. This renders them instead.

### Added
- **DOCX: `{{tex}}` tables render as an embedded image.** The table LaTeX is compiled standalone (`pdflatex` → `pdftoppm @300dpi`, content-hash cached, reusing the existing equation-renderer pattern) and embedded via the existing figure-embedding path. Any `\cite{...}` inside the table is resolved to the document's citation numbers (via the docx citation map) so the image matches the surrounding text. `longtable` blocks are converted to a single `tabular`. **On by default with automatic fallback** to the previous placeholder if a table can't be rendered (no LaTeX toolchain, or a block that fails to compile).

### Fixed (adjacent bugs surfaced by the change)
- **Leaking caption markers.** A `{#stable:label}` caption preceding a `{{tex}}` block (and the `%{#stable:label}` variant, whose `%` hides it from LaTeX) was emitted verbatim instead of as `Supp. Table SN.`. It's now formatted like a Markdown-table caption.
- **Mixed-label numbering.** A single `\label{stable:...}` (e.g. inside a `{{tex}}` table) made the label extractor ignore all `{#stable:...}` markdown labels (an either/or rule), dropping the other SI tables from the numbering. Numbering now merges both forms in document order. (The extractor is DOCX-only; the PDF uses LaTeX's own counters.)

## Test plan
- New unit tests (`tests/unit/test_docx_tex_tables.py`): preprocessor sentinel emission, `\cite` resolution (incl. escaped-cite safety), `longtable`→`tabular` prep, `tex_table` section creation, standalone caption emission, and the label-merge.
- New render integration test (`tests/integration/test_docx_tex_table_render.py`, auto-gated on a LaTeX toolchain).
- Verified end-to-end on **both** the rxiv-maker example manuscript and an external manuscript: 0 leaked markers, table rendered as image, SI captions numbered correctly (S1–S6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)