### PR TITLE
fix: correct Guillaume Jacquemet spelling in injected citation (v1.22.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.1] - 2026-07-09
+
+### Fixed
+- Corrected the spelling of co-author **Guillaume Jacquemet** (previously "Jaquemet",
+  missing the 'c') in the canonical rxiv-maker citation that the tool injects into
+  manuscripts (`citation_utils.py`), as well as in the README citation snippet and the
+  bundled manuscript bibliography. Manuscripts built with earlier versions may carry the
+  misspelled name in their `saraiva_2025_rxivmaker` reference; re-running the build with
+  this version refreshes the injected citation.
+
 ## [1.22.0] - 2026-06-18
 
 ### Added

--- a/MANUSCRIPT/03_REFERENCES.bib
+++ b/MANUSCRIPT/03_REFERENCES.bib
@@ -20,12 +20,12 @@
   publisher    = {Example Publisher}
 }
 @misc{saraiva_2025_rxivmaker,
-      title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques},
-      year={2025},
-      eprint={2508.00836},
-      archivePrefix={arXiv},
-      primaryClass={cs.DL},
-      doi={10.48550/arXiv.2508.00836},
-      url={https://arxiv.org/abs/2508.00836},
+  title        = {Rxiv-Maker: an automated template engine for streamlined scientific publications},
+  author       = {Bruno M. Saraiva and Ant\'{o}nio D. Brito and Guillaume Jacquemet and Ricardo Henriques},
+  year         = 2025,
+  eprint       = {2508.00836},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.DL},
+  doi          = {10.48550/arXiv.2508.00836},
+  url          = {https://arxiv.org/abs/2508.00836}
 }

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Preprints and papers written with Rxiv-Maker are collected on the [Publications 
 ```bibtex
 @misc{saraiva_2025_rxivmaker,
   title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-  author={Bruno M. Saraiva and Ant\'{o}nio D. Brito and Guillaume Jaquemet and Ricardo Henriques},
+  author={Bruno M. Saraiva and Ant\'{o}nio D. Brito and Guillaume Jacquemet and Ricardo Henriques},
   year={2025},
   eprint={2508.00836},
   archivePrefix={arXiv},

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.22.0"
+__version__ = "1.22.1"

--- a/src/rxiv_maker/utils/citation_utils.py
+++ b/src/rxiv_maker/utils/citation_utils.py
@@ -10,7 +10,7 @@ from .unicode_safe import get_safe_icon, safe_print
 # Current canonical rxiv-maker citation
 CANONICAL_RXIV_CITATION = """@misc{saraiva_2025_rxivmaker,
       title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques},
+      author={Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques},
       year={2025},
       eprint={2508.00836},
       archivePrefix={arXiv},
@@ -48,7 +48,7 @@ def is_citation_outdated(existing_citation: str) -> bool:
         True if citation needs updating, False if it's current
     """
     # Extract key fields for comparison
-    current_authors = "Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques"
+    current_authors = "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques"
     current_title = "Rxiv-Maker: an automated template engine for streamlined scientific publications"
     current_eprint = "2508.00836"
     current_doi = "10.48550/arXiv.2508.00836"

--- a/tests/integration/test_citation_injection.py
+++ b/tests/integration/test_citation_injection.py
@@ -100,7 +100,7 @@ Thanks to everyone.
         assert "saraiva_2025_rxivmaker" in updated_bib_content
         assert "Rxiv-Maker: an automated template engine" in updated_bib_content
         assert (
-            "Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques" in updated_bib_content
+            "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" in updated_bib_content
         )
 
         # Verify original content is preserved
@@ -261,7 +261,7 @@ Original acknowledgements.
         bib_content = """
 @misc{saraiva_2025_rxivmaker,
       title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques},
+      author={Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques},
       year={2025},
       eprint={2508.00836},
       archivePrefix={arXiv},
@@ -313,7 +313,7 @@ Original acknowledgements.
 
         # Verify content is correct
         assert "Rxiv-Maker: an automated template engine" in content
-        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques" in content
+        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" in content
 
     def test_acknowledgment_includes_version_in_generated_manuscript(self):
         """Test that acknowledgment text includes version in generated manuscript."""

--- a/tests/unit/test_citation_utils.py
+++ b/tests/unit/test_citation_utils.py
@@ -61,7 +61,7 @@ class TestInjectRxivCitation:
         content = self.bib_file.read_text(encoding="utf-8")
         assert "saraiva_2025_rxivmaker" in content
         assert "Rxiv-Maker: an automated template engine" in content
-        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques" in content
+        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" in content
         assert "2025" in content
         assert "arxiv.org/abs/2508.00836" in content
 
@@ -95,7 +95,7 @@ class TestInjectRxivCitation:
         # Create bibliography with current, complete rxiv-maker citation
         existing_content = """@misc{saraiva_2025_rxivmaker,
       title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques},
+      author={Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques},
       year={2025},
       eprint={2508.00836},
       archivePrefix={arXiv},
@@ -265,7 +265,7 @@ class TestInjectRxivCitation:
         # Validate required BibTeX fields
         assert "@misc{saraiva_2025_rxivmaker," in content
         assert "title={Rxiv-Maker: an automated template engine for streamlined scientific publications}" in content
-        assert "author={Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques}" in content
+        assert "author={Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques}" in content
         assert "year={2025}" in content
         assert "eprint={2508.00836}" in content
         assert "archivePrefix={arXiv}" in content
@@ -292,7 +292,7 @@ class TestInjectRxivCitation:
         # Create bibliography with outdated rxiv-maker citation (missing António D. Brito)
         outdated_content = """@misc{saraiva_2025_rxivmaker,
       title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and Guillaume Jaquemet and Ricardo Henriques},
+      author={Bruno M. Saraiva and Guillaume Jacquemet and Ricardo Henriques},
       year={2025},
       eprint={2508.00836},
       archivePrefix={arXiv},
@@ -315,7 +315,7 @@ class TestInjectRxivCitation:
         # Check content was updated with new author list
         content = self.bib_file.read_text(encoding="utf-8")
         assert "António D. Brito" in content
-        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques" in content
+        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" in content
 
     def test_inject_citation_updates_malformed_citation(self, capsys):
         """Test that malformed citations are updated correctly."""
@@ -356,7 +356,7 @@ class TestInjectRxivCitation:
 
 @misc{saraiva_2025_rxivmaker,
       title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and Guillaume Jaquemet and Ricardo Henriques},
+      author={Bruno M. Saraiva and Guillaume Jacquemet and Ricardo Henriques},
       year={2025}
 }
 
@@ -385,7 +385,7 @@ class TestInjectRxivCitation:
         assert "another2023" in content
         assert "John Smith" in content
         assert "António D. Brito" in content
-        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques" in content
+        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" in content
 
     def test_extract_existing_citation_function(self):
         """Test the extract_existing_citation helper function."""
@@ -433,7 +433,7 @@ class TestInjectRxivCitation:
         # Test outdated citation (missing António D. Brito)
         outdated_citation = """@misc{saraiva_2025_rxivmaker,
       title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and Guillaume Jaquemet and Ricardo Henriques},
+      author={Bruno M. Saraiva and Guillaume Jacquemet and Ricardo Henriques},
       year={2025}
 }"""
         assert is_citation_outdated(outdated_citation) is True
@@ -441,7 +441,7 @@ class TestInjectRxivCitation:
         # Test current citation
         current_citation = """@misc{saraiva_2025_rxivmaker,
       title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and António D. Brito and Guillaume Jaquemet and Ricardo Henriques},
+      author={Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques},
       year={2025},
       eprint={2508.00836},
       doi={10.48550/arXiv.2508.00836}


### PR DESCRIPTION
Corrects the co-author name 'Jaquemet' -> 'Jacquemet' in the citation-injection template (`citation_utils.py`), README snippet, bundled manuscript bib, and citation tests. Version bump to 1.22.1 + CHANGELOG.

Tag `v1.22.1` was already pushed and has triggered the release pipeline (run 29006026567); this PR lands the same commit (b5481e2) on main since direct pushes are blocked by branch protection. Merge with a **merge commit** (not squash) to keep the tag on main's history.