### PR TITLE
fix: refresh rxiv-maker citation authors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Build directories (contains all generated files)
+.worktrees/
 build/
 output/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.2] - 2026-07-13
+
+### Fixed
+- Updated the canonical Rxiv-Maker citation to credit Rita Carlota and Iván Hidalgo-Cenalmor, and refreshed the bundled manuscript bibliography and README snippet. Existing manuscripts now replace the previous four-author citation when rebuilt.
+
 ## [1.22.1] - 2026-07-09
 
 ### Fixed

--- a/MANUSCRIPT/03_REFERENCES.bib
+++ b/MANUSCRIPT/03_REFERENCES.bib
@@ -21,7 +21,7 @@
 }
 @misc{saraiva_2025_rxivmaker,
   title        = {Rxiv-Maker: an automated template engine for streamlined scientific publications},
-  author       = {Bruno M. Saraiva and Ant\'{o}nio D. Brito and Guillaume Jacquemet and Ricardo Henriques},
+  author       = {Bruno M. Saraiva and Rita Carlota and Ant\'{o}nio D. Brito and Iv\'{a}n Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques},
   year         = 2025,
   eprint       = {2508.00836},
   archiveprefix = {arXiv},

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Preprints and papers written with Rxiv-Maker are collected on the [Publications 
 ```bibtex
 @misc{saraiva_2025_rxivmaker,
   title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-  author={Bruno M. Saraiva and Ant\'{o}nio D. Brito and Guillaume Jacquemet and Ricardo Henriques},
+  author={Bruno M. Saraiva and Rita Carlota and Ant\'{o}nio D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques},
   year={2025},
   eprint={2508.00836},
   archivePrefix={arXiv},

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.22.1"
+__version__ = "1.22.2"

--- a/src/rxiv_maker/utils/citation_utils.py
+++ b/src/rxiv_maker/utils/citation_utils.py
@@ -10,7 +10,7 @@ from .unicode_safe import get_safe_icon, safe_print
 # Current canonical rxiv-maker citation
 CANONICAL_RXIV_CITATION = """@misc{saraiva_2025_rxivmaker,
       title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques},
+      author={Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques},
       year={2025},
       eprint={2508.00836},
       archivePrefix={arXiv},
@@ -48,7 +48,10 @@ def is_citation_outdated(existing_citation: str) -> bool:
         True if citation needs updating, False if it's current
     """
     # Extract key fields for comparison
-    current_authors = "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques"
+    current_authors = (
+        "Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor "
+        "and Guillaume Jacquemet and Ricardo Henriques"
+    )
     current_title = "Rxiv-Maker: an automated template engine for streamlined scientific publications"
     current_eprint = "2508.00836"
     current_doi = "10.48550/arXiv.2508.00836"

--- a/tests/integration/test_citation_injection.py
+++ b/tests/integration/test_citation_injection.py
@@ -100,7 +100,8 @@ Thanks to everyone.
         assert "saraiva_2025_rxivmaker" in updated_bib_content
         assert "Rxiv-Maker: an automated template engine" in updated_bib_content
         assert (
-            "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" in updated_bib_content
+            "Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques"
+            in updated_bib_content
         )
 
         # Verify original content is preserved
@@ -277,6 +278,34 @@ Original acknowledgements.
                 content = bib_file.read_text(encoding="utf-8")
                 assert "saraiva_2025_rxivmaker" in content
 
+    def test_citation_injection_refreshes_stale_entry(self):
+        """Test that a previously injected citation is refreshed to the current authors."""
+        bib_file = self.manuscript_dir / "03_REFERENCES.bib"
+        bib_file.write_text(
+            """@misc{saraiva_2025_rxivmaker,
+      title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
+      author={Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques},
+      year={2025},
+      eprint={2508.00836},
+      archivePrefix={arXiv},
+      primaryClass={cs.DL},
+      doi={10.48550/arXiv.2508.00836},
+      url={https://arxiv.org/abs/2508.00836},
+}""",
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"MANUSCRIPT_PATH": str(self.manuscript_dir)}):
+            with patch("pathlib.Path.cwd", return_value=Path(self.temp_dir)):
+                inject_rxiv_citation({"acknowledge_rxiv_maker": True})
+
+        content = bib_file.read_text(encoding="utf-8")
+        assert (
+            "Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques"
+            in content
+        )
+        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" not in content
+
     def test_citation_injection_error_handling(self):
         """Test that citation injection handles various error conditions gracefully."""
         test_metadata = {"acknowledge_rxiv_maker": True}
@@ -313,7 +342,10 @@ Original acknowledgements.
 
         # Verify content is correct
         assert "Rxiv-Maker: an automated template engine" in content
-        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" in content
+        assert (
+            "Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques"
+            in content
+        )
 
     def test_acknowledgment_includes_version_in_generated_manuscript(self):
         """Test that acknowledgment text includes version in generated manuscript."""

--- a/tests/unit/test_citation_utils.py
+++ b/tests/unit/test_citation_utils.py
@@ -61,7 +61,10 @@ class TestInjectRxivCitation:
         content = self.bib_file.read_text(encoding="utf-8")
         assert "saraiva_2025_rxivmaker" in content
         assert "Rxiv-Maker: an automated template engine" in content
-        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" in content
+        assert (
+            "Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques"
+            in content
+        )
         assert "2025" in content
         assert "arxiv.org/abs/2508.00836" in content
 
@@ -95,7 +98,7 @@ class TestInjectRxivCitation:
         # Create bibliography with current, complete rxiv-maker citation
         existing_content = """@misc{saraiva_2025_rxivmaker,
       title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques},
+      author={Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques},
       year={2025},
       eprint={2508.00836},
       archivePrefix={arXiv},
@@ -265,7 +268,10 @@ class TestInjectRxivCitation:
         # Validate required BibTeX fields
         assert "@misc{saraiva_2025_rxivmaker," in content
         assert "title={Rxiv-Maker: an automated template engine for streamlined scientific publications}" in content
-        assert "author={Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques}" in content
+        assert (
+            "author={Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques}"
+            in content
+        )
         assert "year={2025}" in content
         assert "eprint={2508.00836}" in content
         assert "archivePrefix={arXiv}" in content
@@ -315,7 +321,10 @@ class TestInjectRxivCitation:
         # Check content was updated with new author list
         content = self.bib_file.read_text(encoding="utf-8")
         assert "António D. Brito" in content
-        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" in content
+        assert (
+            "Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques"
+            in content
+        )
 
     def test_inject_citation_updates_malformed_citation(self, capsys):
         """Test that malformed citations are updated correctly."""
@@ -385,7 +394,10 @@ class TestInjectRxivCitation:
         assert "another2023" in content
         assert "John Smith" in content
         assert "António D. Brito" in content
-        assert "Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques" in content
+        assert (
+            "Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques"
+            in content
+        )
 
     def test_extract_existing_citation_function(self):
         """Test the extract_existing_citation helper function."""
@@ -441,7 +453,7 @@ class TestInjectRxivCitation:
         # Test current citation
         current_citation = """@misc{saraiva_2025_rxivmaker,
       title={Rxiv-Maker: an automated template engine for streamlined scientific publications},
-      author={Bruno M. Saraiva and António D. Brito and Guillaume Jacquemet and Ricardo Henriques},
+      author={Bruno M. Saraiva and Rita Carlota and António D. Brito and Iván Hidalgo-Cenalmor and Guillaume Jacquemet and Ricardo Henriques},
       year={2025},
       eprint={2508.00836},
       doi={10.48550/arXiv.2508.00836}


### PR DESCRIPTION
## Summary
- add Rita Carlota and Iván Hidalgo-Cenalmor to the canonical Rxiv-Maker citation
- refresh old injected citations on rebuild
- bump version to 1.22.2 and update bundled citation references

## Verification
- `uv run --with pytest pytest tests/integration/test_citation_injection.py -q`
- `uv run --with ruff ruff check src/rxiv_maker/utils/citation_utils.py tests/integration/test_citation_injection.py`
- `uv build`