### PR TITLE
fix(docx): honour citation_style and protect code spans (1.22.3)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,4 +54,8 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # The prompt asks Claude to read CLAUDE.md and review the code, so it
+          # needs Read/Glob/Grep in addition to the gh Bash commands it uses to
+          # post its review. Without these the run hits permission denials and,
+          # on current claude-code-action, fails the job.
+          claude_args: '--allowed-tools "Read,Glob,Grep,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -17,6 +17,8 @@ https://github.com/user/repo
 
 # URLs that require authentication
 https://github.com/settings
+# GitHub serves 404 to anonymous requests for this page; the badge link is fine in a browser
+https://github.com/HenriquesLab/rxiv-maker/stargazers
 
 # Known temporary unavailability (remove when fixed)
 # Add specific URLs here if they're temporarily down

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,10 @@ repos:
     rev: 1.8.5
     hooks:
       - id: bandit
-        args: [-r, --format, custom, --skip, B101,B601,B602,B603,B604,B605,B607,B608]
+        # Keep the skip list quoted: an unquoted comma list inside a YAML flow
+        # sequence splits into separate items, so --skip would take only the
+        # first code and treat the rest as file paths.
+        args: [-r, --format, custom, --skip, "B101,B404,B601,B602,B603,B604,B605,B606,B607,B608"]
         exclude: ^(tests/|versioneer\.py|src/py/_version\.py|git_submodules/.*|.*test.*\.py|examples/.*)$
 
   # Notebook output stripping (clean notebooks before commit)
@@ -85,7 +88,7 @@ repos:
     hooks:
       - id: lazydocs-generate
         name: Generate API documentation
-        entry: python src/rxiv_maker/engines/operations/generate_docs.py
+        entry: python3 src/rxiv_maker/engines/operations/generate_docs.py
         language: system
         files: ^src/rxiv_maker/.*\.py$
         exclude: ^git_submodules/.*$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.3] - 2026-08-10
+
+### Fixed
+- DOCX export now honours the `citation_style` config key. Previously the DOCX
+  writer always emitted numbered citations (`[1]`) and a numbered reference list,
+  even when `citation_style: "author-date"` was set, so the PDF and DOCX built from
+  the same sources disagreed. Author-date exports now render `(Smith et al., 2021)`
+  for bracketed citations, `Smith et al. (2021)` for narrative ones, and an
+  unnumbered reference list sorted alphabetically. Entries sharing an author and
+  year are disambiguated as `2021a`, `2021b`. This matters for journals that reject
+  numbered citations.
+- DOCX export no longer converts citation syntax inside code spans. Markdown such
+  as ``` `[@smith2021]` ``` in a tutorial rendered as `[29]` in the DOCX while the
+  PDF kept it verbatim, because the DOCX path protected code spans when extracting
+  citations but not when replacing them. Fenced blocks and inline spans are now
+  protected on both passes.
+- DOCX export warns when a cited bibliography entry has no `author` field, which
+  would otherwise cite as `Anon.` in author-date style while the reference list
+  showed a different fallback.
+
 ## [1.22.2] - 2026-07-13
 
 ### Fixed

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.22.2"
+__version__ = "1.22.3"

--- a/src/rxiv_maker/exporters/docx_citation_mapper.py
+++ b/src/rxiv_maker/exporters/docx_citation_mapper.py
@@ -1,18 +1,126 @@
 """Citation mapper for DOCX export.
 
-This module provides functionality to map citation keys to sequential numbers
-for numbered citation format in DOCX exports.
+This module maps citation keys to their in-text representation for DOCX
+exports, supporting both numbered ([1]) and author-date ((Smith et al., 2021))
+styles as selected by the ``citation_style`` config key.
 """
 
 import re
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from ..converters.citation_processor import extract_citations_from_text
 from ..utils.citation_range_formatter import format_citation_ranges
 
+# An author-date label carries both rendering forms: parenthetical for
+# bracketed citations and textual for narrative ones.
+AuthorDateLabel = Dict[str, str]
+CitationValue = Union[int, AuthorDateLabel]
+
+
+def _surname(name: str) -> str:
+    """Extract a surname from a single BibTeX author name."""
+    name = name.strip().strip("{}").strip()
+    if not name:
+        return ""
+    if "," in name:
+        return name.split(",")[0].strip().strip("{}")
+    parts = name.split()
+    return parts[-1].strip("{}") if parts else ""
+
+
+def _author_label(author_field: str) -> str:
+    """Build the author portion of an author-date citation."""
+    names = [n for n in (p.strip() for p in author_field.split(" and ")) if n]
+    surnames = [s for s in (_surname(n) for n in names) if s]
+    if not surnames:
+        return "Anon."
+    if len(surnames) == 1:
+        return surnames[0]
+    if len(surnames) == 2:
+        return f"{surnames[0]} and {surnames[1]}"
+    return f"{surnames[0]} et al."
+
 
 class CitationMapper:
-    """Maps citation keys to sequential numbers for DOCX export."""
+    """Maps citation keys to their in-text form for DOCX export."""
+
+    def __init__(self, citation_style: str = "numbered"):
+        """Initialise the mapper.
+
+        Args:
+            citation_style: Either "numbered" or "author-date"
+        """
+        self.citation_style = citation_style
+
+    @staticmethod
+    def _protect_code(text: str):
+        """Replace fenced and inline code with placeholders.
+
+        Citation syntax shown as a code example must survive verbatim. Fenced
+        blocks are matched before inline spans so a single backtick cannot pair
+        across a fence boundary.
+        """
+        blocks: List[str] = []
+
+        def stash(match):
+            blocks.append(match.group(0))
+            return f"__DOCX_CODE_SPAN_{len(blocks) - 1}__"
+
+        text = re.sub(r"```.*?```", stash, text, flags=re.DOTALL)
+        text = re.sub(r"`[^`]+`", stash, text)
+        return text, blocks
+
+    @staticmethod
+    def _restore_code(text: str, blocks: List[str]) -> str:
+        """Reinstate code spans stashed by :meth:`_protect_code`."""
+        for i, block in enumerate(blocks):
+            text = text.replace(f"__DOCX_CODE_SPAN_{i}__", block)
+        return text
+
+    def create_author_date_mapping(self, citations: List[str], entries_by_key: Dict) -> Dict[str, AuthorDateLabel]:
+        """Create citation key to author-date label mapping.
+
+        Keys sharing an author-year pair are disambiguated with a letter suffix
+        in order of first appearance, giving (Smith, 2021a) and (Smith, 2021b).
+
+        Args:
+            citations: Ordered list of citation keys (by first appearance)
+            entries_by_key: Bibliography entries keyed by citation key
+
+        Returns:
+            Dict mapping each key to its parenthetical and textual forms
+        """
+        seen = set()
+        unique = []
+        for cite in citations:
+            if cite not in seen:
+                seen.add(cite)
+                unique.append(cite)
+
+        base: Dict[str, tuple] = {}
+        for key in unique:
+            entry = entries_by_key.get(key)
+            if entry is None:
+                continue
+            author = _author_label(entry.fields.get("author", ""))
+            year = entry.fields.get("year", "n.d.").strip()
+            base[key] = (author, year)
+
+        collisions: Dict[tuple, List[str]] = {}
+        for key, pair in base.items():
+            collisions.setdefault(pair, []).append(key)
+
+        mapping: Dict[str, AuthorDateLabel] = {}
+        for key, (author, year) in base.items():
+            shared = collisions[(author, year)]
+            suffix = chr(ord("a") + shared.index(key)) if len(shared) > 1 else ""
+            stamped = f"{year}{suffix}"
+            mapping[key] = {
+                "paren": f"{author}, {stamped}",
+                "text": f"{author} ({stamped})",
+                "sort": f"{author} {stamped}".lower(),
+            }
+        return mapping
 
     @staticmethod
     def _format_citation_ranges(text: str) -> str:
@@ -74,18 +182,20 @@ class CitationMapper:
         """
         return extract_citations_from_text(text)
 
-    def replace_citations_in_text(self, text: str, citation_map: Dict[str, int]) -> str:
-        """Replace @key citations with [number] format in text.
+    def replace_citations_in_text(self, text: str, citation_map: Dict[str, CitationValue]) -> str:
+        """Replace @key citations with their rendered in-text form.
 
         Handles both single citations (@key) and multiple citations ([@key1;@key2]).
-        Preserves figure and equation references (@fig:, @eq:, @tbl:).
+        Preserves figure and equation references (@fig:, @eq:, @tbl:), and leaves
+        citation syntax inside code spans untouched so tutorials can show it.
 
         Args:
             text: Text containing markdown citations
-            citation_map: Mapping from citation keys to numbers
+            citation_map: Mapping from citation keys to numbers, or to
+                author-date labels when citation_style is "author-date"
 
         Returns:
-            Text with citations replaced by numbers
+            Text with citations replaced
 
         Example:
             >>> mapper = CitationMapper()
@@ -94,7 +204,13 @@ class CitationMapper:
             >>> mapper.replace_citations_in_text(text, mapping)
             'Study by [1] and others [2, 3]'
         """
-        # First, protect email addresses by temporarily replacing them
+        author_date = self.citation_style == "author-date"
+
+        # Citation syntax shown as a code example is documentation, not a
+        # citation, so hide it before any substitution runs.
+        text, code_blocks = self._protect_code(text)
+
+        # Protect email addresses by temporarily replacing them
         email_patterns = []
 
         def protect_email(match):
@@ -109,12 +225,13 @@ class CitationMapper:
             cite_text = match.group(1)
             # Split by semicolon and extract keys
             keys = [k.strip().lstrip("@").strip() for k in cite_text.split(";")]
-            # Map to numbers
-            numbers = [str(citation_map[k]) for k in keys if k in citation_map]
-            if numbers:
-                return f"[{', '.join(numbers)}]"
-            # If no valid citations found, return original
-            return match.group(0)
+            rendered = [citation_map[k] for k in keys if k in citation_map]
+            if not rendered:
+                # If no valid citations found, return original
+                return match.group(0)
+            if author_date:
+                return f"({'; '.join(r['paren'] for r in rendered)})"
+            return f"[{', '.join(str(r) for r in rendered)}]"
 
         text = re.sub(r"\[@([^]]+)\]", replace_bracketed, text)
 
@@ -122,6 +239,8 @@ class CitationMapper:
         def replace_single(match):
             key = match.group(1)
             if key in citation_map:
+                if author_date:
+                    return citation_map[key]["text"]
                 return f"[{citation_map[key]}]"
             # If key not in mapping, return original
             return match.group(0)
@@ -136,7 +255,9 @@ class CitationMapper:
         for i, pattern in enumerate(email_patterns):
             text = text.replace(f"__EMAIL_PATTERN_{i}__", pattern)
 
-        # Format consecutive citations as ranges (e.g., [1][2][3] -> [1-3])
-        text = self._format_citation_ranges(text)
+        # Ranges are meaningless for author-date labels.
+        if not author_date:
+            # Format consecutive citations as ranges (e.g., [1][2][3] -> [1-3])
+            text = self._format_citation_ranges(text)
 
-        return text
+        return self._restore_code(text, code_blocks)

--- a/src/rxiv_maker/exporters/docx_exporter.py
+++ b/src/rxiv_maker/exporters/docx_exporter.py
@@ -61,6 +61,7 @@ class DocxExporter:
         config_manager = ConfigManager(base_dir=Path(manuscript_path))
         config = config_manager.load_config()
         self.author_format = config.get("bibliography_author_format", "lastname_firstname")
+        self.citation_style = config.get("citation_style", "numbered")
 
         # DOCX export options
         docx_config = config.get("docx", {})
@@ -75,7 +76,7 @@ class DocxExporter:
         self.tables_as_images = tables_as_images or docx_config.get("tables_as_images", False)
 
         # Components
-        self.citation_mapper = CitationMapper()
+        self.citation_mapper = CitationMapper(citation_style=self.citation_style)
         self.content_processor = DocxContentProcessor()
         self.writer = DocxWriter()
 
@@ -140,6 +141,19 @@ class DocxExporter:
         # Step 4: Build bibliography
         bibliography = self._build_bibliography(citation_map)
         logger.info(f"Built bibliography with {len(bibliography)} entries")
+
+        # Author-date needs labels rather than numbers in the text, and an
+        # alphabetised reference list keyed to those labels.
+        if self.citation_style == "author-date":
+            entries_by_key = {info["key"]: info["entry"] for info in bibliography.values()}
+            authorless = [k for k, e in entries_by_key.items() if not e.fields.get("author", "").strip()]
+            if authorless:
+                logger.warning(
+                    f"{len(authorless)} bibliography entry(ies) have no author field and will cite as "
+                    f"'Anon.' in author-date style: {', '.join(sorted(authorless))}"
+                )
+            citation_map = self.citation_mapper.create_author_date_mapping(citations, entries_by_key)
+            bibliography = self._reorder_bibliography_alphabetically(bibliography, citation_map)
 
         # Step 5: Replace citations in text
         markdown_with_numbers = self.citation_mapper.replace_citations_in_text(markdown_content, citation_map)
@@ -291,6 +305,7 @@ class DocxExporter:
             figures_at_end=self.figures_at_end,
             hide_highlighting=self.hide_highlighting,
             hide_comments=self.hide_comments,
+            citation_style=self.citation_style,
         )
         logger.info(f"DOCX exported successfully: {docx_path}")
 
@@ -443,6 +458,24 @@ class DocxExporter:
             logger.warning(f"{len(missing_keys)} citation(s) not found in bibliography: {', '.join(missing_keys)}")
 
         return bibliography
+
+    def _reorder_bibliography_alphabetically(
+        self, bibliography: Dict[int, Dict], citation_map: Dict
+    ) -> Dict[int, Dict]:
+        """Re-key a bibliography into alphabetical author-date order.
+
+        Args:
+            bibliography: Bibliography keyed by citation-order number
+            citation_map: Author-date labels keyed by citation key
+
+        Returns:
+            Bibliography re-keyed so ascending keys give alphabetical order
+        """
+        ordered = sorted(
+            bibliography.values(),
+            key=lambda info: citation_map.get(info["key"], {}).get("sort", info["key"].lower()),
+        )
+        return {idx + 1: info for idx, info in enumerate(ordered)}
 
     def _resolve_doi_from_metadata(self, entry) -> str | None:
         """Resolve DOI from entry metadata using CrossRef API.

--- a/src/rxiv_maker/exporters/docx_writer.py
+++ b/src/rxiv_maker/exporters/docx_writer.py
@@ -109,6 +109,7 @@ class DocxWriter:
         figures_at_end: bool = False,
         hide_highlighting: bool = False,
         hide_comments: bool = False,
+        citation_style: str = "numbered",
     ) -> Path:
         """Write DOCX file from structured content.
 
@@ -124,6 +125,8 @@ class DocxWriter:
             figures_at_end: Place main figures at end before SI/bibliography
             hide_highlighting: Disable colored highlighting on references and citations
             hide_comments: Exclude all comments (block and inline) from output
+            citation_style: "numbered" or "author-date"; author-date omits the
+                bracketed number prefix on each reference list entry
 
         Returns:
             Path to created DOCX file
@@ -197,14 +200,15 @@ class DocxWriter:
             for run in heading.runs:
                 run.font.color.rgb = RGBColor(0, 0, 0)  # Ensure black text
 
-            # Add numbered bibliography entries
+            # Add bibliography entries; author-date lists are unnumbered
             for num in sorted(bibliography.keys()):
                 bib_entry = bibliography[num]
                 para = doc.add_paragraph()
 
-                # Add citation number in bold
-                num_run = para.add_run(f"[{num}] ")
-                num_run.bold = True
+                if citation_style != "author-date":
+                    # Add citation number in bold
+                    num_run = para.add_run(f"[{num}] ")
+                    num_run.bold = True
 
                 # Add formatted bibliography text (without DOI - added separately below)
                 para.add_run(bib_entry["formatted"])

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -17,17 +17,18 @@ This fixture contains a comprehensive test manuscript that validates Guillaume's
 import pytest
 from pathlib import Path
 
+
 def test_guillaume_fixes():
     """Test Guillaume's fixes using the fixture manuscript."""
     fixture_dir = Path(__file__).parent.parent / "fixtures"
     manuscript_dir = fixture_dir
-    
+
     # Test manuscript contains:
     # - Ready figures in FIGURES/Fig1.png, Fig2.png, etc.
     # - Panel references with Guillaume's specific formatting
     # - Introduction section (not Main)
     # - Full-page positioning examples
-    
+
     # Run your tests here...
 ```
 

--- a/tests/unit/exporters/test_docx_citation_mapper.py
+++ b/tests/unit/exporters/test_docx_citation_mapper.py
@@ -218,3 +218,123 @@ class TestCitationMapper:
         assert "@smith2021" not in result  # Replaced
         assert "@jones2022" not in result  # Replaced
         assert "@brown2023" not in result  # Replaced
+
+
+class TestCodeSpanProtection:
+    """Citation syntax shown as a code example must survive verbatim."""
+
+    def test_inline_code_citation_not_replaced(self):
+        """Backticked citation syntax stays literal in numbered style."""
+        mapper = CitationMapper()
+        text = "For example, you would write `[@Knuth1984]`."
+        result = mapper.replace_citations_in_text(text, {"Knuth1984": 29})
+
+        assert "`[@Knuth1984]`" in result
+        assert "[29]" not in result
+
+    def test_inline_code_protected_while_real_citation_converts(self):
+        """A literal example and a real citation coexist in one paragraph."""
+        mapper = CitationMapper()
+        text = "Write `[@smith2021]` to cite it [@smith2021]."
+        result = mapper.replace_citations_in_text(text, {"smith2021": 1})
+
+        assert "`[@smith2021]`" in result
+        assert result.count("[1]") == 1
+
+    def test_fenced_code_block_protected(self):
+        """Fenced blocks are protected as a whole."""
+        mapper = CitationMapper()
+        text = "Example:\n```\n[@smith2021]\n```\nReal: [@smith2021]"
+        result = mapper.replace_citations_in_text(text, {"smith2021": 1})
+
+        assert "```\n[@smith2021]\n```" in result
+        assert result.count("[1]") == 1
+
+    def test_bare_key_in_code_protected(self):
+        """A bare @key inside backticks is not a citation."""
+        mapper = CitationMapper()
+        text = "Use `@smith2021` syntax, as in @smith2021."
+        result = mapper.replace_citations_in_text(text, {"smith2021": 1})
+
+        assert "`@smith2021`" in result
+        assert "[1]" in result
+
+
+class TestAuthorDateStyle:
+    """Author-date rendering for journals that reject numbered citations."""
+
+    @staticmethod
+    def _entries():
+        from rxiv_maker.utils.bibliography_parser import BibEntry
+
+        def entry(key, author, year):
+            return BibEntry(
+                key=key,
+                entry_type="article",
+                fields={"author": author, "year": year, "title": "T", "journal": "J"},
+                raw="",
+            )
+
+        return {
+            "solo2021": entry("solo2021", "Smith, John", "2021"),
+            "pair2022": entry("pair2022", "Jones, A. and Brown, B.", "2022"),
+            "many2023": entry("many2023", "Alpha, A. and Beta, B. and Gamma, G.", "2023"),
+            "dup2021": entry("dup2021", "Smith, John", "2021"),
+        }
+
+    def _mapping(self):
+        mapper = CitationMapper(citation_style="author-date")
+        keys = ["solo2021", "pair2022", "many2023", "dup2021"]
+        return mapper, mapper.create_author_date_mapping(keys, self._entries())
+
+    def test_single_surname_label(self):
+        _, mapping = self._mapping()
+        assert mapping["solo2021"]["paren"] == "Smith, 2021a"
+
+    def test_two_authors_joined_with_and(self):
+        _, mapping = self._mapping()
+        assert mapping["pair2022"]["paren"] == "Jones and Brown, 2022"
+
+    def test_three_plus_surnames_use_et_al(self):
+        _, mapping = self._mapping()
+        assert mapping["many2023"]["paren"] == "Alpha et al., 2023"
+
+    def test_colliding_surname_date_suffixes(self):
+        """Colliding author-year pairs get letter suffixes in citation order."""
+        _, mapping = self._mapping()
+        assert mapping["solo2021"]["paren"] == "Smith, 2021a"
+        assert mapping["dup2021"]["paren"] == "Smith, 2021b"
+
+    def test_bracketed_citation_is_parenthetical(self):
+        mapper, mapping = self._mapping()
+        result = mapper.replace_citations_in_text("Shown before [@many2023].", mapping)
+        assert result == "Shown before (Alpha et al., 2023)."
+
+    def test_narrative_citation_is_textual(self):
+        mapper, mapping = self._mapping()
+        result = mapper.replace_citations_in_text("As @many2023 showed.", mapping)
+        assert result == "As Alpha et al. (2023) showed."
+
+    def test_multiple_citations_separated_by_semicolon(self):
+        mapper, mapping = self._mapping()
+        result = mapper.replace_citations_in_text("[@pair2022;@many2023]", mapping)
+        assert result == "(Jones and Brown, 2022; Alpha et al., 2023)"
+
+    def test_no_numeric_brackets_emitted(self):
+        """The whole point: nothing renders as [N]."""
+        import re
+
+        mapper, mapping = self._mapping()
+        text = "See [@solo2021;@pair2022] and @many2023 too."
+        result = mapper.replace_citations_in_text(text, mapping)
+        assert not re.search(r"\[\d+", result)
+
+    def test_code_spans_protected_in_authordate(self):
+        mapper, mapping = self._mapping()
+        result = mapper.replace_citations_in_text("Write `[@solo2021]` here.", mapping)
+        assert "`[@solo2021]`" in result
+
+    def test_cross_references_preserved(self):
+        mapper, mapping = self._mapping()
+        result = mapper.replace_citations_in_text("See @fig:one and [@solo2021].", mapping)
+        assert "@fig:one" in result

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -44,4 +44,4 @@ Add new manuscripts to this directory when you need to:
 
 - [User Guide](../../docs/user_guide.md) - For user-facing examples
 - [Figures Guide](../../docs/figures-guide.md) - Figure usage documentation
-- [Developer Guide]() - Development workflows
+- [Contributing Guide](../../CONTRIBUTING.md) - Development workflows


### PR DESCRIPTION
## Summary

Two DOCX export bugs, both found while preparing the JCS revision of the Rxiv-Maker paper itself.

### 1. DOCX ignored `citation_style`

The DOCX exporter hardcoded numbered citations. `citation_style` was read nowhere in the DOCX path (`exporters/`, `docx_helpers.py`, `cli/commands/docx.py`), while the LaTeX path honoured it. A manuscript configured as `citation_style: "author-date"` built a PDF with `(Brito et al., 2025)` and a DOCX with `[11]` from the same sources.

This blocks submission to journals that reject numbered citations. Journal of Cell Science states it plainly: *"We cannot accept papers where the in-text citations are referred to by numbers."*

Author-date DOCX exports now produce:
- `(Smith et al., 2021)` for bracketed citations, `Smith et al. (2021)` for narrative ones
- one author `Smith`, two `Jones and Brown`, three or more `Alpha et al.`
- an unnumbered reference list sorted alphabetically
- `2021a` / `2021b` suffixes where an author and year collide

Numbered style is untouched, including range collapsing (`[1-3]`).

### 2. Citations inside code spans were converted

A tutorial line reading ``you would write `[@Knuth1984_literate_programming]` `` rendered as `you would write [29].` in the DOCX while the PDF kept it verbatim. Citation *extraction* protected fenced and inline code; citation *replacement* did not. Both passes now protect it.

A reviewer hit this in the published preprint, which is how it surfaced.

### 3. Warning for authorless entries

Cited entries with no `author` field silently cited as `Anon.` while the reference list showed a different fallback. The exporter now warns and names the keys.

## Pre-commit repairs

Both hooks failed on any change touching `docx_writer.py`:

- **bandit**: the skip list sat unquoted inside a YAML flow sequence, so it split on commas. `--skip` received only `B101` and the remaining codes were passed as file paths. Quoting it restores the intended list, which now matches `[tool.bandit]` in `pyproject.toml`.
- **lazydocs**: the hook invoked `python`, which does not exist on systems providing only `python3`.

## Testing

14 new tests in `tests/unit/exporters/test_docx_citation_mapper.py` covering code-span protection and author-date rendering.

Full unit suite: 1634 passed, same 11 pre-existing failures as `main` (async manager, arxiv command, validators, citation rendering), no new failures.

Verified end to end on the JCS manuscript: numeric in-text citations went 64 to 0, author-date citations 0 to 33, and the Knuth code example survives intact.

> Note: several existing `test_replace_citations_*` tests never run locally, because a conftest heuristic marks any test whose name contains `r_` or starts with `test_r` as requiring R. That is why these bugs went unnoticed. Left alone here to keep the patch focused, but worth a follow-up.