### PR TITLE
fix(docx): clean LaTeX escapes in author-date citations (1.22.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.4] - 2026-08-10
+
+### Fixed
+- Author-date DOCX citations no longer leak LaTeX escapes from the bibliography.
+  A BibTeX author field such as `Popovi\'{c}` rendered as `Popovi\'{c` in the
+  in-text citation, because the author-date label read the raw field while the
+  reference list cleaned it. The label now runs the same cleaning pass.
+- LaTeX accent conversion now handles the general braced form `\X{letter}`, which
+  is what BibTeX files normally carry. The previous literal lookup table covered
+  `\'e` and `{\'e}` but not `\'{e}`, so `Popovi\'{c}` degraded to `Popovi'c` and
+  `Pylv\"{a}n\"{a}inen` to `Pylv"an"ainen` in DOCX reference lists. Acute, grave,
+  circumflex, diaeresis, tilde, macron, dot, breve, caron, double acute, cedilla,
+  ogonek and ring are composed to Unicode via combining marks.
+
 ## [1.22.3] - 2026-08-10
 
 ### Fixed

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.22.3"
+__version__ = "1.22.4"

--- a/src/rxiv_maker/exporters/docx_citation_mapper.py
+++ b/src/rxiv_maker/exporters/docx_citation_mapper.py
@@ -29,7 +29,14 @@ def _surname(name: str) -> str:
 
 
 def _author_label(author_field: str) -> str:
-    """Build the author portion of an author-date citation."""
+    r"""Build the author portion of an author-date citation.
+
+    BibTeX author fields carry LaTeX escapes (``Popovi\'{c}``), so clean them to
+    Unicode first; otherwise the escape leaks into the rendered citation.
+    """
+    from ..utils.docx_helpers import clean_latex_commands
+
+    author_field = clean_latex_commands(author_field)
     names = [n for n in (p.strip() for p in author_field.split(" and ")) if n]
     surnames = [s for s in (_surname(n) for n in names) if s]
     if not surnames:

--- a/src/rxiv_maker/utils/accent_character_map.py
+++ b/src/rxiv_maker/utils/accent_character_map.py
@@ -11,7 +11,31 @@ Examples:
     'Café'
 """
 
+import re
+import unicodedata
 from typing import Dict
+
+# LaTeX accent command -> Unicode combining mark. Used by the general
+# `\X{letter}` pass below, which covers arbitrary letter/accent pairs that the
+# literal ACCENT_MAP cannot enumerate (e.g. \'{c} -> ć, \"{a} -> ä).
+COMBINING_MARKS: Dict[str, str] = {
+    "'": "\u0301",  # acute
+    "`": "\u0300",  # grave
+    "^": "\u0302",  # circumflex
+    '"': "\u0308",  # diaeresis
+    "~": "\u0303",  # tilde
+    "=": "\u0304",  # macron
+    ".": "\u0307",  # dot above
+    "u": "\u0306",  # breve
+    "v": "\u030c",  # caron
+    "H": "\u030b",  # double acute
+    "c": "\u0327",  # cedilla
+    "k": "\u0328",  # ogonek
+    "r": "\u030a",  # ring above
+}
+
+# Matches \'{c}, \"{a}, \v{s}, and the brace-wrapped {\'{c}} variant.
+_ACCENT_BRACED = re.compile(r"\{?\\([\'`^\"~=.uvHckr])\{(\\i|\\j|[A-Za-z])\}\}?")
 
 # LaTeX accent commands to Unicode character mapping
 # Handles both with and without backslashes (BibTeX parser may strip them)
@@ -144,7 +168,29 @@ def clean_latex_accents(text: str) -> str:
         'Café'
         >>> clean_latex_accents("Se\\~nor")
         'Señor'
+        >>> clean_latex_accents("Popovi\\'{c}")
+        'Popović'
     """
     for latex_cmd, unicode_char in ACCENT_MAP.items():
         text = text.replace(latex_cmd, unicode_char)
-    return text
+    return _apply_braced_accents(text)
+
+
+def _apply_braced_accents(text: str) -> str:
+    r"""Convert the general ``\X{letter}`` accent form to composed Unicode.
+
+    The literal ACCENT_MAP cannot enumerate every accent/letter pair, and the
+    braced form is what BibTeX files normally carry. Compose the letter with the
+    matching combining mark and normalise, so ``\'{c}`` becomes ``ć``.
+    """
+
+    def replace(match: re.Match) -> str:
+        accent, letter = match.group(1), match.group(2)
+        # Dotless i/j take the accent on the plain letter.
+        letter = {"\\i": "i", "\\j": "j"}.get(letter, letter)
+        mark = COMBINING_MARKS.get(accent)
+        if mark is None:
+            return match.group(0)
+        return unicodedata.normalize("NFC", letter + mark)
+
+    return _ACCENT_BRACED.sub(replace, text)

--- a/tests/unit/exporters/test_docx_citation_mapper.py
+++ b/tests/unit/exporters/test_docx_citation_mapper.py
@@ -338,3 +338,41 @@ class TestAuthorDateStyle:
         mapper, mapping = self._mapping()
         result = mapper.replace_citations_in_text("See @fig:one and [@solo2021].", mapping)
         assert "@fig:one" in result
+
+
+class TestAccentedNames:
+    """BibTeX LaTeX escapes must not leak into rendered citations."""
+
+    @staticmethod
+    def _entry(key, author, year):
+        from rxiv_maker.utils.bibliography_parser import BibEntry
+
+        return BibEntry(
+            key=key,
+            entry_type="article",
+            fields={"author": author, "year": year, "title": "T", "journal": "J"},
+            raw="",
+        )
+
+    def test_braced_acute_becomes_unicode(self):
+        """The standard BibTeX \\'{c} form composes to a single character."""
+        mapper = CitationMapper(citation_style="author-date")
+        entries = {"pop2025": self._entry("pop2025", "Popovi\\'{c}, Ana and Ball, Neil", "2025")}
+        mapping = mapper.create_author_date_mapping(["pop2025"], entries)
+        assert mapping["pop2025"]["paren"] == "Popović and Ball, 2025"
+
+    def test_braced_diaeresis_becomes_unicode(self):
+        mapper = CitationMapper(citation_style="author-date")
+        entries = {"pyl2025": self._entry("pyl2025", 'Pylv\\"{a}n\\"{a}inen, Joanna', "2025")}
+        mapping = mapper.create_author_date_mapping(["pyl2025"], entries)
+        assert mapping["pyl2025"]["paren"] == "Pylvänäinen, 2025"
+
+    def test_no_latex_escape_survives_into_text(self):
+        """Guards the exact defect seen in the JCS build: Popovi\\'{c literal."""
+        mapper = CitationMapper(citation_style="author-date")
+        entries = {"pop2025": self._entry("pop2025", "Popovi\\'{c}, Ana", "2025")}
+        mapping = mapper.create_author_date_mapping(["pop2025"], entries)
+        out = mapper.replace_citations_in_text("Shown in [@pop2025].", mapping)
+        assert "\\" not in out
+        assert "{" not in out
+        assert out == "Shown in (Popović, 2025)."


### PR DESCRIPTION
Follow-up to #315, found by diffing a rebuilt JCS manuscript against the file actually submitted to the journal.

## The defect

Author-date in-text citations read the raw BibTeX `author` field, so `Popovi\'{c}` rendered as the literal `Popovi\'{c` in the DOCX. The reference list, which does clean the field, showed something different again, so the same author appeared two ways in one document.

## Why cleaning alone was not enough

`ACCENT_MAP` is a literal lookup table listing `\'e` and `{\'e}` but not `\'{e}`, which is the form BibTeX files normally carry. So even the cleaned reference-list path degraded:

| BibTeX | before | after |
|---|---|---|
| `Popovi\'{c}` | `Popovi'c` | `Popović` |
| `Pylv\"{a}n\"{a}inen` | `Pylv"an"ainen` | `Pylvänäinen` |
| `Iv\'{a}n` | `Iv'an` | `Iván` |

The LaTeX/PDF path was always correct, since TeX renders the accent natively. This was DOCX-only.

A general `\X{letter}` pass now composes the letter with the matching Unicode combining mark, covering acute, grave, circumflex, diaeresis, tilde, macron, dot, breve, caron, double acute, cedilla, ogonek and ring. The literal table still runs first, so existing behaviour is unchanged.

## Testing

3 new tests in `TestAccentedNames`, including one guarding the exact string seen in the JCS build. Verified no regression on the previously-working `{\'e}` form.

Full unit suite: 1637 passed, same 11 pre-existing failures as main.