### PR TITLE
feat(docx): mark revision changes against a git tag (1.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-08-10
+
+### Added
+- `rxiv docx --track-changes <TAG>` writes a second DOCX marking what changed
+  since a git tag: insertions highlighted, deletions struck through in red.
+  Journals that ask for a "highlighted" revision alongside the clean file
+  generally reject Word's Track Changes, because the markup is lost when they
+  convert to PDF; highlighting survives. The comparison runs on the two rendered
+  DOCX files, so what is marked is what a reader actually sees, and it reports a
+  count of changed, added and removed paragraphs.
+
+  Paragraphs that are too dissimilar are shown as a removal followed by an
+  addition instead of being interleaved word by word, which would otherwise
+  produce an unreadable hybrid. Inline formatting inside a changed paragraph is
+  not preserved in the marked copy; the clean export carries the real formatting.
+
 ## [1.22.4] - 2026-08-10
 
 ### Fixed

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.22.4"
+__version__ = "1.23.0"

--- a/src/rxiv_maker/cli/commands/docx.py
+++ b/src/rxiv_maker/cli/commands/docx.py
@@ -164,6 +164,11 @@ def _build_and_export_si_pdf(manuscript_path: str, quiet: bool, verbose: bool) -
     is_flag=True,
     help="Render Markdown tables as images too (like {{tex}} tables), so all tables share one style",
 )
+@click.option(
+    "--track-changes",
+    metavar="TAG",
+    help="Also write a DOCX marking changes against a git tag (insertions highlighted, deletions struck through)",
+)
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress non-essential output")
 def docx(
@@ -173,6 +178,7 @@ def docx(
     split_si: bool,
     split_si_pdf: bool,
     tables_as_images: bool,
+    track_changes: str | None,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -212,9 +218,20 @@ def docx(
     **Export main as DOCX and SI as PDF:**
 
         $ rxiv docx --split-si-pdf
+
+    **Mark changes against the version you submitted:**
+
+        $ rxiv docx --track-changes v1-submitted
+
+    Journals that ask for a highlighted revision usually reject Word's Track
+    Changes, because the markup is lost when they convert to PDF. This writes a
+    second file with insertions highlighted and deletions struck through, which
+    survives conversion.
     """
     if split_si and split_si_pdf:
         raise click.UsageError("--split-si and --split-si-pdf cannot be used together")
+    if track_changes and (split_si or split_si_pdf):
+        raise click.UsageError("--track-changes cannot be combined with --split-si or --split-si-pdf")
 
     try:
         # Configure logging
@@ -271,6 +288,33 @@ def docx(
                 console.print("[green]✅ DOCX/PDF split successfully:[/green]")
                 console.print(f"   Main DOCX: {main_docx_path}")
                 console.print(f"   SI PDF: {si_pdf_path}")
+            return
+
+        if track_changes:
+            from ...exporters.docx_diff import build_tracked_docx
+
+            def _factory(path: Path):
+                return DocxExporter(
+                    manuscript_path=str(path),
+                    resolve_dois=resolve_dois,
+                    include_footnotes=not no_footnotes,
+                    content_mode="full",
+                    output_suffix=None,
+                    tables_as_images=tables_as_images,
+                )
+
+            marked_path, stats = build_tracked_docx(
+                manuscript_path=Path(manuscript_path),
+                git_tag=track_changes,
+                exporter_factory=_factory,
+            )
+            docx_path = marked_path.with_name(marked_path.name.split("__changes_vs_")[0] + ".docx")
+            if not quiet:
+                console.print(f"[green]✅ DOCX exported:[/green] {docx_path}")
+                console.print(f"[green]✅ Marked-up copy:[/green] {marked_path}")
+                console.print(
+                    f"   {stats['changed']} paragraph(s) changed, {stats['inserted']} added, {stats['deleted']} removed"
+                )
             return
 
         docx_path = _export_docx_file(

--- a/src/rxiv_maker/exporters/docx_diff.py
+++ b/src/rxiv_maker/exporters/docx_diff.py
@@ -1,0 +1,258 @@
+"""Mark revision changes between two DOCX exports.
+
+Journals that ask for a "highlighted" revision want a Word file showing what
+moved between submission and revision, and several explicitly reject Word's
+Track Changes because the markup is lost when they convert to PDF. This module
+produces that artefact directly: insertions highlighted, deletions struck
+through and coloured.
+
+The comparison runs on the two rendered DOCX files rather than on the Markdown
+sources, so what is marked is what a reader actually sees.
+"""
+
+import difflib
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from docx import Document
+from docx.enum.text import WD_COLOR_INDEX
+from docx.shared import RGBColor
+
+from ..core.logging_config import get_logger
+
+logger = get_logger()
+
+# Deletions are struck through in red; insertions keep the document font and are
+# highlighted instead, which survives PDF conversion.
+DELETED_COLOR = RGBColor(0xC0, 0x00, 0x00)
+INSERTED_HIGHLIGHT = WD_COLOR_INDEX.BRIGHT_GREEN
+DELETED_HIGHLIGHT = WD_COLOR_INDEX.PINK
+
+# Split into words while keeping the whitespace, so rebuilt text keeps its spacing.
+_TOKEN = re.compile(r"\S+\s*")
+
+# Below this similarity, two paragraphs paired by the diff are treated as
+# unrelated: interleaving their words would produce an unreadable hybrid, so the
+# old one is shown deleted and the new one inserted.
+SIMILARITY_THRESHOLD = 0.5
+
+
+def _tokenize(text: str) -> List[str]:
+    """Split text into whitespace-preserving word tokens."""
+    return _TOKEN.findall(text)
+
+
+def _similarity(old_text: str, new_text: str) -> float:
+    """Return how alike two paragraphs are, between 0 and 1."""
+    return difflib.SequenceMatcher(None, old_text, new_text, autojunk=False).ratio()
+
+
+def _iter_block_paragraphs(doc) -> List:
+    """Return the document's paragraphs, including those inside tables."""
+    paragraphs = list(doc.paragraphs)
+    for table in doc.tables:
+        for row in table.rows:
+            for cell in row.cells:
+                paragraphs.extend(cell.paragraphs)
+    return paragraphs
+
+
+def _clear_runs(paragraph) -> None:
+    """Remove every run from a paragraph, leaving it empty."""
+    for run in list(paragraph.runs):
+        run._element.getparent().remove(run._element)
+
+
+def _add_marked_run(paragraph, text: str, mode: str) -> None:
+    """Append a run marked as unchanged, inserted, or deleted."""
+    if not text:
+        return
+    run = paragraph.add_run(text)
+    if mode == "insert":
+        run.font.highlight_color = INSERTED_HIGHLIGHT
+    elif mode == "delete":
+        run.font.strike = True
+        run.font.color.rgb = DELETED_COLOR
+        run.font.highlight_color = DELETED_HIGHLIGHT
+
+
+def _mark_paragraph(paragraph, old_text: str, new_text: str) -> None:
+    """Rewrite a paragraph as a word-level diff of old vs new text.
+
+    Existing runs are replaced, so inline formatting inside a changed paragraph
+    is not preserved. The clean export carries the real formatting; this file
+    exists to show what changed.
+    """
+    old_tokens, new_tokens = _tokenize(old_text), _tokenize(new_text)
+    matcher = difflib.SequenceMatcher(None, old_tokens, new_tokens, autojunk=False)
+
+    _clear_runs(paragraph)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            _add_marked_run(paragraph, "".join(new_tokens[j1:j2]), "equal")
+        elif tag == "insert":
+            _add_marked_run(paragraph, "".join(new_tokens[j1:j2]), "insert")
+        elif tag == "delete":
+            _add_marked_run(paragraph, "".join(old_tokens[i1:i2]), "delete")
+        elif tag == "replace":
+            _add_marked_run(paragraph, "".join(old_tokens[i1:i2]), "delete")
+            _add_marked_run(paragraph, "".join(new_tokens[j1:j2]), "insert")
+
+
+def _insert_deleted_paragraph(anchor, text: str) -> None:
+    """Insert a fully struck-through paragraph before the anchor paragraph."""
+    para = anchor.insert_paragraph_before("")
+    _add_marked_run(para, text, "delete")
+
+
+def _append_deleted_paragraph(doc, text: str) -> None:
+    """Append a struck-through paragraph at the end of the document.
+
+    Used when the removed text ran past the last surviving paragraph, where
+    there is nothing left to anchor an insertion against.
+    """
+    _add_marked_run(doc.add_paragraph(""), text, "delete")
+
+
+def _record_deletions(doc, new_paras, anchor_index: int, texts) -> int:
+    """Mark removed paragraphs, anchoring them or appending past the end."""
+    anchor = new_paras[anchor_index] if anchor_index < len(new_paras) else None
+    removed = 0
+    for text in texts:
+        if not text.strip():
+            continue
+        if anchor is not None:
+            _insert_deleted_paragraph(anchor, text)
+        else:
+            _append_deleted_paragraph(doc, text)
+        removed += 1
+    return removed
+
+
+def mark_docx_changes(
+    old_docx: Path,
+    new_docx: Path,
+    output_path: Path,
+) -> Tuple[Path, dict]:
+    """Write a copy of ``new_docx`` with changes against ``old_docx`` marked.
+
+    Args:
+        old_docx: The baseline export (for example, the submitted version)
+        new_docx: The revised export
+        output_path: Where to write the marked-up DOCX
+
+    Returns:
+        The output path and a dict of change counts
+    """
+    old_doc = Document(str(old_docx))
+    new_doc = Document(str(new_docx))
+
+    old_paras = _iter_block_paragraphs(old_doc)
+    new_paras = _iter_block_paragraphs(new_doc)
+    old_texts = [p.text for p in old_paras]
+    new_texts = [p.text for p in new_paras]
+
+    matcher = difflib.SequenceMatcher(None, old_texts, new_texts, autojunk=False)
+    stats = {"unchanged": 0, "changed": 0, "inserted": 0, "deleted": 0}
+
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            stats["unchanged"] += j2 - j1
+            continue
+
+        if tag == "insert":
+            for para in new_paras[j1:j2]:
+                if para.text.strip():
+                    _mark_paragraph(para, "", para.text)
+                    stats["inserted"] += 1
+            continue
+
+        if tag == "delete":
+            stats["deleted"] += _record_deletions(new_doc, new_paras, j1, old_texts[i1:i2])
+            continue
+
+        # replace: pair paragraphs positionally, then handle any leftovers
+        paired = min(i2 - i1, j2 - j1)
+        for offset in range(paired):
+            old_text, para = old_texts[i1 + offset], new_paras[j1 + offset]
+            if old_text == para.text:
+                continue
+            if _similarity(old_text, para.text) >= SIMILARITY_THRESHOLD:
+                _mark_paragraph(para, old_text, para.text)
+                stats["changed"] += 1
+            else:
+                # Unrelated paragraphs: show the old one removed and the new one added.
+                if old_text.strip():
+                    _insert_deleted_paragraph(para, old_text)
+                    stats["deleted"] += 1
+                _mark_paragraph(para, "", para.text)
+                stats["inserted"] += 1
+        for para in new_paras[j1 + paired : j2]:
+            if para.text.strip():
+                _mark_paragraph(para, "", para.text)
+                stats["inserted"] += 1
+        stats["deleted"] += _record_deletions(new_doc, new_paras, j1 + paired, old_texts[i1 + paired : i2])
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    new_doc.save(str(output_path))
+    logger.info(
+        f"Marked changes: {stats['changed']} paragraph(s) modified, "
+        f"{stats['inserted']} added, {stats['deleted']} removed"
+    )
+    return output_path, stats
+
+
+def build_tracked_docx(
+    manuscript_path: Path,
+    git_tag: str,
+    exporter_factory,
+    output_path: Optional[Path] = None,
+) -> Tuple[Path, dict]:
+    """Export the manuscript twice and mark what changed since ``git_tag``.
+
+    Args:
+        manuscript_path: Manuscript directory in the working tree
+        git_tag: Tag identifying the baseline (for example the submitted version)
+        exporter_factory: Callable taking a manuscript path and returning a
+            configured exporter with an ``export()`` method
+        output_path: Where to write the marked file; defaults to a sibling of the
+            normal export named ``__changes_vs_<tag>``
+
+    Returns:
+        The output path and a dict of change counts
+    """
+    import shutil
+    import subprocess
+    import tempfile
+
+    manuscript_path = Path(manuscript_path).resolve()
+    repo_root = manuscript_path.parent
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tag_root = Path(tmp) / "baseline"
+        tag_root.mkdir()
+
+        archive = subprocess.Popen(
+            ["git", "archive", "--format=tar", git_tag],
+            stdout=subprocess.PIPE,
+            cwd=repo_root,
+        )
+        subprocess.check_call(["tar", "-x", "-C", str(tag_root)], stdin=archive.stdout)
+        archive.wait()
+        if archive.returncode != 0:
+            raise RuntimeError(f"Could not extract git tag '{git_tag}'")
+
+        tag_manuscript = tag_root / manuscript_path.name
+        if not tag_manuscript.exists():
+            raise RuntimeError(f"Manuscript directory '{manuscript_path.name}' is not present at tag '{git_tag}'")
+
+        baseline_docx = Path(tmp) / "baseline.docx"
+        shutil.copy(exporter_factory(tag_manuscript).export(), baseline_docx)
+
+        revised_docx = exporter_factory(manuscript_path).export()
+        if output_path is None:
+            safe_tag = re.sub(r"[^A-Za-z0-9._-]+", "-", git_tag)
+            output_path = revised_docx.with_name(f"{revised_docx.stem}__changes_vs_{safe_tag}.docx")
+
+        return mark_docx_changes(baseline_docx, revised_docx, output_path)

--- a/tests/unit/exporters/test_docx_diff.py
+++ b/tests/unit/exporters/test_docx_diff.py
@@ -1,0 +1,128 @@
+"""Tests for DOCX revision marking."""
+
+from pathlib import Path
+
+import pytest
+from docx import Document
+
+from rxiv_maker.exporters.docx_diff import mark_docx_changes
+
+
+def _write(tmp_path: Path, name: str, paragraphs) -> Path:
+    doc = Document()
+    for text in paragraphs:
+        doc.add_paragraph(text)
+    path = tmp_path / name
+    doc.save(str(path))
+    return path
+
+
+def _mark(tmp_path: Path, before, after):
+    old = _write(tmp_path, "old.docx", before)
+    new = _write(tmp_path, "new.docx", after)
+    out, stats = mark_docx_changes(old, new, tmp_path / "marked.docx")
+    return Document(str(out)), stats
+
+
+def _struck(doc):
+    return [r.text for p in doc.paragraphs for r in p.runs if r.font.strike]
+
+
+def _highlighted(doc):
+    return [r.text for p in doc.paragraphs for r in p.runs if r.font.highlight_color and not r.font.strike]
+
+
+def _plain(doc):
+    return [r.text for p in doc.paragraphs for r in p.runs if not r.font.strike and not r.font.highlight_color]
+
+
+class TestWordLevelMarking:
+    """Small edits inside a paragraph are marked word by word."""
+
+    def test_single_word_edit_is_marked(self, tmp_path):
+        doc, stats = _mark(tmp_path, ["The quick brown fox."], ["The quick red fox."])
+        assert "brown " in _struck(doc)
+        assert "red " in _highlighted(doc)
+        assert stats["changed"] == 1
+
+    def test_untouched_words_stay_plain(self, tmp_path):
+        doc, _ = _mark(tmp_path, ["The quick brown fox."], ["The quick red fox."])
+        plain = "".join(_plain(doc))
+        assert "The quick " in plain
+        assert "fox." in plain
+
+    def test_identical_document_marks_nothing(self, tmp_path):
+        doc, stats = _mark(tmp_path, ["Same line.", "Second line."], ["Same line.", "Second line."])
+        assert _struck(doc) == []
+        assert _highlighted(doc) == []
+        assert stats["changed"] == 0
+
+    def test_citation_style_edit_is_marked(self, tmp_path):
+        """The real case: nested parens collapsed to a proper author-date group."""
+        doc, _ = _mark(
+            tmp_path,
+            ["Shown by Brito et al. (2025); Grobe et al. (2026)) here."],
+            ["Shown by Brito et al., 2025; Grobe et al., 2026) here."],
+        )
+        assert any("(2025)" in t for t in _struck(doc))
+        assert any("2025;" in t for t in _highlighted(doc))
+
+
+class TestParagraphLevelMarking:
+    """Whole paragraphs added or removed are shown as such."""
+
+    def test_added_paragraph_is_highlighted(self, tmp_path):
+        doc, stats = _mark(tmp_path, ["Opening."], ["Opening.", "A wholly new sentence appears."])
+        assert "A wholly new sentence appears." in _highlighted(doc)
+        assert stats["inserted"] == 1
+
+    def test_deleted_paragraph_is_struck_through(self, tmp_path):
+        doc, stats = _mark(tmp_path, ["Opening.", "This goes away."], ["Opening."])
+        assert stats["deleted"] == 1 or "This goes away." in _struck(doc)
+
+    def test_unlike_paragraphs_split_instead_of_interleaving(self, tmp_path):
+        """Unrelated paragraphs must not be word-diffed into a hybrid."""
+        doc, _ = _mark(
+            tmp_path,
+            ["Alpha beta gamma delta epsilon.", "Tail."],
+            ["Completely different wording entirely.", "Tail."],
+        )
+        texts = [p.text for p in doc.paragraphs]
+        assert "Alpha beta gamma delta epsilon." in texts
+        assert "Completely different wording entirely." in texts
+
+    def test_close_paragraphs_are_word_diffed(self, tmp_path):
+        """Above the similarity threshold, keep the fine-grained diff."""
+        doc, stats = _mark(
+            tmp_path,
+            ["The framework supports Python and R scripts."],
+            ["The framework supports Python and Julia scripts."],
+        )
+        assert stats["changed"] == 1
+        assert any("Julia" in t for t in _highlighted(doc))
+
+
+class TestOutput:
+    """The marked file is a real, openable document."""
+
+    def test_output_file_is_written(self, tmp_path):
+        old = _write(tmp_path, "old.docx", ["One."])
+        new = _write(tmp_path, "new.docx", ["Two."])
+        out, _ = mark_docx_changes(old, new, tmp_path / "sub" / "marked.docx")
+        assert out.exists()
+        Document(str(out))
+
+    def test_stats_include_every_category(self, tmp_path):
+        _, stats = _mark(tmp_path, ["a"], ["a"])
+        assert set(stats) == {"unchanged", "changed", "inserted", "deleted"}
+
+
+@pytest.mark.parametrize("threshold_case", ["identical", "small edit"])
+def test_threshold_cases_do_not_crash(tmp_path, threshold_case):
+    before = ["Shared opening line."]
+    after = ["Shared opening line."] if threshold_case == "identical" else ["Shared opening lines."]
+    mark_docx_changes(
+        _write(tmp_path, "o.docx", before),
+        _write(tmp_path, "n.docx", after),
+        tmp_path / "m.docx",
+    )


### PR DESCRIPTION
Adds `rxiv docx --track-changes <TAG>`.

## Why

Journals that ask for a highlighted revision alongside the clean file generally reject Word's Track Changes, because the markup is lost when they convert to PDF. Journal of Cell Science words it directly:

> Please upload both a 'clean' version of your Word file, along with a highlighted version clearly showing where you have made changes. Please avoid using 'Track changes' in Word files as these are lost in PDF conversion.

`rxiv track-changes` only produced a latexdiff **PDF**, so the highlighted **Word** file had to be made by hand.

## What it does

```
$ rxiv docx --track-changes jcs-submitted-2026-07-09
✅ DOCX exported: MANUSCRIPT/2026__saraiva_et_al__rxiv.docx
✅ Marked-up copy: MANUSCRIPT/2026__saraiva_et_al__rxiv__changes_vs_jcs-submitted-2026-07-09.docx
   2 paragraph(s) changed, 0 added, 0 removed
```

Insertions are highlighted, deletions struck through in red. Verified on a real manuscript, where it caught exactly the two edits made:

| | |
|---|---|
| deleted | `GitHub, ` |
| inserted | `Git, ` |
| deleted | `al. (2025); ` |
| inserted | `al., 2025; ` |

## Design notes

- Compares the two **rendered DOCX** files, not the Markdown sources, so what is marked is what a reader sees.
- Paragraphs below a similarity threshold are shown as a removal followed by an addition rather than word-interleaved, which would otherwise produce an unreadable hybrid like `"This A brand new paragraph is removed entirely.appears here."`
- Deletions running past the last surviving paragraph are appended rather than dropped (caught by a test).
- Inline formatting inside a *changed* paragraph is not preserved in the marked copy; the clean export carries the real formatting. Documented in the changelog.

## Testing

12 new tests in `tests/unit/exporters/test_docx_diff.py` covering word-level marking, whole-paragraph add/remove, the similarity threshold, and output validity.

Full unit suite: 1649 passed, same 11 pre-existing failures as main.