### PR TITLE
chore: add Zenodo and citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,77 @@
+{
+  "title": "Rxiv-Maker: an automated template engine for streamlined scientific publications",
+  "description": "<p>Rxiv-Maker converts a plain-text Markdown manuscript into a submission-ready article, as a PDF or an editable Word document, with consistent styling, automatic figure and citation numbering, and reliable cross-referencing.</p><p>For quantitative work it can optionally regenerate figures and recompute reported values directly from the data during compilation, so the text stays consistent with the analysis behind it. It builds on familiar tools such as Git and Visual Studio Code, and produces submission packages for arXiv and bioRxiv.</p><p>This record archives a tagged release of the framework together with its example manuscript and data, so the exact version used to produce a given paper can be retrieved and cited.</p>",
+  "upload_type": "software",
+  "license": "MIT",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Saraiva, Bruno M.",
+      "affiliation": "Instituto de Tecnologia Química e Biológica António Xavier, Universidade Nova de Lisboa, Oeiras, Portugal",
+      "orcid": "0000-0002-9151-5477"
+    },
+    {
+      "name": "Carlota, Rita",
+      "affiliation": "Instituto de Tecnologia Química e Biológica António Xavier, Universidade Nova de Lisboa, Oeiras, Portugal",
+      "orcid": "0000-0003-3647-1114"
+    },
+    {
+      "name": "Brito, António D.",
+      "affiliation": "Instituto de Tecnologia Química e Biológica António Xavier, Universidade Nova de Lisboa, Oeiras, Portugal",
+      "orcid": "0009-0001-1769-2627"
+    },
+    {
+      "name": "Hidalgo-Cenalmor, Iván",
+      "affiliation": "Turku Bioscience Centre, University of Turku and Åbo Akademi University, Turku, Finland",
+      "orcid": "0009-0000-8923-568X"
+    },
+    {
+      "name": "Jacquemet, Guillaume",
+      "affiliation": "Faculty of Science and Engineering, Cell Biology, Åbo Akademi University, Turku, Finland",
+      "orcid": "0000-0002-9286-920X"
+    },
+    {
+      "name": "Henriques, Ricardo",
+      "affiliation": "Instituto de Tecnologia Química e Biológica António Xavier, Universidade Nova de Lisboa, Oeiras, Portugal",
+      "orcid": "0000-0002-2043-5234"
+    }
+  ],
+  "keywords": [
+    "scientific publishing",
+    "preprints",
+    "reproducible research",
+    "Markdown",
+    "LaTeX",
+    "open-source software",
+    "bioimage analysis",
+    "manuscript preparation"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "10.48550/arXiv.2508.00836",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/HenriquesLab/rxiv-maker",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://rxiv-maker.henriqueslab.org",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    }
+  ],
+  "grants": [
+    {
+      "id": "10.13039/501100000781::101001332"
+    },
+    {
+      "id": "10.13039/501100000781::101057970"
+    },
+    {
+      "id": "10.13039/501100000781::101099654"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,73 @@
+cff-version: 1.2.0
+message: "If you use Rxiv-Maker, please cite the paper below."
+title: "Rxiv-Maker: an automated template engine for streamlined scientific publications"
+abstract: >-
+  Rxiv-Maker converts a plain-text Markdown manuscript into a submission-ready
+  article, as a PDF or an editable Word document, with consistent styling,
+  automatic figure and citation numbering, and reliable cross-referencing. For
+  quantitative work it can optionally regenerate figures and recompute reported
+  values directly from the data during compilation, so the text stays consistent
+  with the analysis behind it.
+type: software
+license: MIT
+repository-code: "https://github.com/HenriquesLab/rxiv-maker"
+url: "https://rxiv-maker.henriqueslab.org"
+keywords:
+  - scientific publishing
+  - preprints
+  - reproducible research
+  - Markdown
+  - LaTeX
+  - open-source software
+  - bioimage analysis
+  - manuscript preparation
+authors:
+  - family-names: Saraiva
+    given-names: "Bruno M."
+    orcid: "https://orcid.org/0000-0002-9151-5477"
+    affiliation: "Instituto de Tecnologia Química e Biológica António Xavier, Universidade Nova de Lisboa, Oeiras, Portugal"
+  - family-names: Carlota
+    given-names: Rita
+    orcid: "https://orcid.org/0000-0003-3647-1114"
+    affiliation: "Instituto de Tecnologia Química e Biológica António Xavier, Universidade Nova de Lisboa, Oeiras, Portugal"
+  - family-names: Brito
+    given-names: "António D."
+    orcid: "https://orcid.org/0009-0001-1769-2627"
+    affiliation: "Instituto de Tecnologia Química e Biológica António Xavier, Universidade Nova de Lisboa, Oeiras, Portugal"
+  - family-names: Hidalgo-Cenalmor
+    given-names: Iván
+    orcid: "https://orcid.org/0009-0000-8923-568X"
+    affiliation: "Turku Bioscience Centre, University of Turku and Åbo Akademi University, Turku, Finland"
+  - family-names: Jacquemet
+    given-names: Guillaume
+    orcid: "https://orcid.org/0000-0002-9286-920X"
+    affiliation: "Faculty of Science and Engineering, Cell Biology, Åbo Akademi University, Turku, Finland"
+  - family-names: Henriques
+    given-names: Ricardo
+    orcid: "https://orcid.org/0000-0002-2043-5234"
+    affiliation: "Instituto de Tecnologia Química e Biológica António Xavier, Universidade Nova de Lisboa, Oeiras, Portugal"
+preferred-citation:
+  type: article
+  title: "Rxiv-Maker: an automated template engine for streamlined scientific publications"
+  year: 2025
+  doi: "10.48550/arXiv.2508.00836"
+  url: "https://arxiv.org/abs/2508.00836"
+  authors:
+    - family-names: Saraiva
+      given-names: "Bruno M."
+      orcid: "https://orcid.org/0000-0002-9151-5477"
+    - family-names: Carlota
+      given-names: Rita
+      orcid: "https://orcid.org/0000-0003-3647-1114"
+    - family-names: Brito
+      given-names: "António D."
+      orcid: "https://orcid.org/0009-0001-1769-2627"
+    - family-names: Hidalgo-Cenalmor
+      given-names: Iván
+      orcid: "https://orcid.org/0009-0000-8923-568X"
+    - family-names: Jacquemet
+      given-names: Guillaume
+      orcid: "https://orcid.org/0000-0002-9286-920X"
+    - family-names: Henriques
+      given-names: Ricardo
+      orcid: "https://orcid.org/0000-0002-2043-5234"


### PR DESCRIPTION
Reviewer 2 of the rxiv-maker paper asked for versioned releases and example data in a long-term archive with persistent DOIs.

## What I found

A Zenodo deposit already exists and is healthy in principle: concept DOI [10.5281/zenodo.15752358](https://doi.org/10.5281/zenodo.15752358), 23 versions archived. But it **stopped at v1.4.12a on 2025-08-04**, because the GitHub integration had been switched off. Everything from v1.4.13 to v1.23.0 is missing from the archive.

The existing record also carries metadata the integration inferred rather than metadata we chose:

| field | current record | should be |
|---|---|---|
| resource type | Journal article | Software |
| licence | CC-BY-4.0 | MIT (matches the code) |
| creators | 3 | 6, with ORCIDs |

## This PR

- `.zenodo.json` sets type, licence, the full six-author byline with ORCIDs and affiliations, keywords, related identifiers (arXiv DOI, repo, docs site) and the three ERC grant IDs.
- `CITATION.cff` gives GitHub's "Cite this repository" button the same author list, and points `preferred-citation` at the arXiv paper. Validated against schema 1.2.0 with cffconvert.

The GitHub integration has now been re-enabled for this repository, so the next release will archive a current version and pick up this metadata.