### PR TITLE
chore: release 1.23.1 to re-archive in Zenodo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.1] - 2026-08-10
+
+### Changed
+- Releases are archived in Zenodo again. The GitHub integration had been off
+  since August 2025, so the archive stopped at v1.4.12a and every release since
+  was missing. `.zenodo.json` and `CITATION.cff` now set the deposit metadata
+  explicitly: resource type software, licence MIT, and the full six-author
+  byline with ORCIDs, replacing the values the integration had inferred.
+  Concept DOI: 10.5281/zenodo.15752358.
+
 ## [1.23.0] - 2026-08-10
 
 ### Added

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.23.0"
+__version__ = "1.23.1"


### PR DESCRIPTION
Version bump so the newly re-enabled GitHub-Zenodo integration has a current release to archive.

The archive had stopped at v1.4.12a (August 2025) because the integration was switched off. It is on again, and #319 landed the `.zenodo.json` that tells Zenodo to record this as **software** under **MIT** with the full **six-author** byline, replacing the inferred "Journal article / CC-BY-4.0 / three authors" metadata on the existing record.

Concept DOI: [10.5281/zenodo.15752358](https://doi.org/10.5281/zenodo.15752358).