### PR TITLE
fix: correct .zenodo.json licence and grant identifiers (1.23.2)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,7 @@
   "title": "Rxiv-Maker: an automated template engine for streamlined scientific publications",
   "description": "<p>Rxiv-Maker converts a plain-text Markdown manuscript into a submission-ready article, as a PDF or an editable Word document, with consistent styling, automatic figure and citation numbering, and reliable cross-referencing.</p><p>For quantitative work it can optionally regenerate figures and recompute reported values directly from the data during compilation, so the text stays consistent with the analysis behind it. It builds on familiar tools such as Git and Visual Studio Code, and produces submission packages for arXiv and bioRxiv.</p><p>This record archives a tagged release of the framework together with its example manuscript and data, so the exact version used to produce a given paper can be retrieved and cited.</p>",
   "upload_type": "software",
-  "license": "MIT",
+  "license": "mit",
   "access_right": "open",
   "creators": [
     {
@@ -65,13 +65,13 @@
   ],
   "grants": [
     {
-      "id": "10.13039/501100000781::101001332"
+      "id": "00k4n6c32::101001332"
     },
     {
-      "id": "10.13039/501100000781::101057970"
+      "id": "00k4n6c32::101057970"
     },
     {
-      "id": "10.13039/501100000781::101099654"
+      "id": "00k4n6c32::101099654"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.2] - 2026-08-10
+
+### Fixed
+- Corrected `.zenodo.json` so the Zenodo deposit validates. The licence was
+  given as `MIT` where Zenodo's identifier is lowercase `mit`, and the grant
+  identifiers used the funder-DOI form where Zenodo expects the ROR form
+  (`00k4n6c32::101001332`). The v1.23.1 archive attempt failed on this.
+
 ## [1.23.1] - 2026-08-10
 
 ### Changed

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.23.1"
+__version__ = "1.23.2"


### PR DESCRIPTION
The v1.23.1 archive attempt **failed**. GitHub delivered the release webhook (202 accepted), then Zenodo rejected the metadata server-side.

Two invalid values in the `.zenodo.json` added in #319, both verified against Zenodo's own vocabularies:

| field | was | Zenodo expects |
|---|---|---|
| `license` | `MIT` | `mit` (from `/api/vocabularies/licenses`) |
| `grants[].id` | `10.13039/501100000781::101001332` | `00k4n6c32::101001332` (from `/api/awards`) |

All three ERC awards resolve under the ROR form. This release retries the archive.