### PR TITLE
feat: Add figure legend continuation support for long captions (#324)

### DIFF
--- a/docs/figures-guide.md
+++ b/docs/figures-guide.md
@@ -248,6 +248,32 @@ showing correlation between variables A and B (n=150, p<0.001).](FIGURES/SFigure
 
 **When to use:** Data visualizations, statistical plots, dynamic content
 
+### 6. Long Figure Legend Continuation
+
+For multi-panel or detailed figures where a long legend needs to continue on the next page:
+
+```markdown
+![](FIGURES/Figure1.png)
+{#fig:cell-migration width="0.70" tex_position="p"} **Cell migration is regulated by matrix organisation.**
+
+(**A**) Overview of the experimental workflow.
+(**B**) Representative microscopy images.
+
+---continued---
+
+(**E--H**) Time-lapse imaging and analysis of protrusion dynamics.
+(**E**) Representative time-lapse images of cells migrating through tissue barrier.
+```
+
+Or with a custom continuation header:
+```markdown
+---continued: (Continued from page 1)---
+```
+
+**Behavior:**
+- **LaTeX**: Emits a `\ContinuedFloat` environment placed at the top of the next page (`[t!]`), keeping the same figure number without duplicate List of Figures entries.
+- **DOCX**: Appends the continued caption as a formatted follow-up paragraph with the continuation header.
+
 ---
 
 ## Troubleshooting

--- a/src/rxiv_maker/converters/figure_processor.py
+++ b/src/rxiv_maker/converters/figure_processor.py
@@ -169,11 +169,36 @@ def parse_figure_attributes(attr_string: str) -> FigureAttributes:
     return attributes
 
 
+def extract_continued_caption(caption_text: str) -> Tuple[str, Optional[str], str]:
+    """Extract main caption, continued caption, and continued header from caption text.
+
+    Looks for `---continued---` or `---continued: Header---` separators in caption_text.
+
+    Returns:
+        Tuple of (main_caption, continued_caption or None, continued_header)
+    """
+    pattern = re.compile(
+        r"^(.*?)\r?\n[ \t]*---+[ \t]*continued(?:[ \t]*:[ \t]*(.*?))?[ \t]*---+[ \t]*\r?\n(.*)$",
+        re.DOTALL,
+    )
+    match = pattern.search(caption_text)
+    if match:
+        main_cap = match.group(1).strip()
+        hdr_raw = match.group(2)
+        continued_hdr = hdr_raw.strip() if hdr_raw and hdr_raw.strip() else "(Continued from previous page.)"
+        cont_cap = match.group(3).strip()
+        return main_cap, cont_cap, continued_hdr
+
+    return caption_text.strip(), None, "(Continued from previous page.)"
+
+
 def create_latex_figure_environment(
     path: str,
     caption: str,
     attributes: Optional[Dict[str, Any]] = None,
     is_supplementary: bool = False,
+    continued_caption: Optional[str] = None,
+    continued_header: Optional[str] = "(Continued from previous page.)",
 ) -> str:
     if attributes is None:
         attributes = {}
@@ -395,6 +420,37 @@ def create_latex_figure_environment(
 
     # Wrapper width: \textwidth for two-column spanning, \linewidth for single-column
     wrapper_width = r"\textwidth" if is_twocol_fig else r"\linewidth"
+    cont_cap = continued_caption or (attributes.get("continued_caption") if attributes else None)
+    cont_hdr = (
+        continued_header
+        or (attributes.get("continued_header") if attributes else None)
+        or "(Continued from previous page.)"
+    )
+
+    continued_latex = ""
+    if cont_cap:
+        proc_cont_cap = re.sub(r"\*\*([^*]+)\*\*", r"\\textbf{\1}", cont_cap)
+        proc_cont_cap = re.sub(r"\*([^*]+)\*", r"\\textit{\1}", proc_cont_cap)
+
+        hdr_str = cont_hdr.strip() if cont_hdr else "(Continued from previous page.)"
+        if not (hdr_str.startswith("\\textbf{") or hdr_str.startswith("**")):
+            hdr_str = f"\\textbf{{{hdr_str}}}"
+        else:
+            hdr_str = re.sub(r"\*\*([^*]+)\*\*", r"\\textbf{\1}", hdr_str)
+
+        cont_lines = [
+            f"\n\\begin{{{env_name}}}[t!]",
+            r"\ContinuedFloat",
+            r"\begingroup",
+            rf"\captionsetup{{width={cap_width_for_env},singlelinecheck=false,justification=justified}}",
+            r"\setlength{\abovecaptionskip}{6pt}\setlength{\belowcaptionskip}{6pt}",
+            r"\ifdefined\justifying\justifying\fi",
+            f"\\caption[]{{{hdr_str} {proc_cont_cap}}}",
+            r"\endgroup",
+            f"\\end{{{env_name}}}",
+        ]
+        continued_latex = "\n" + "\n".join(cont_lines)
+
     lines = [
         f"\n\\begin{{{env_name}}}{position}",
         r"\centering",
@@ -408,10 +464,7 @@ def create_latex_figure_environment(
     if barrier:
         lines.append(r"\FloatBarrier")
     lines.append("")
-    latex_figure = "\n".join(lines)
-
-    # No wrapper needed - LaTeX's float algorithm with [p!] handles dedicated pages correctly
-    # Any clearpage/FloatBarrier wrapper creates white space by preventing subsequent text flow
+    latex_figure = "\n".join(lines) + continued_latex
 
     return latex_figure
 
@@ -456,7 +509,7 @@ def _process_new_figure_format(text: MarkdownContent, is_supplementary: bool = F
         (?P<caption>                     # caption until the next blank line or EOF
             (?s:.*?)                     # DOTALL, non-greedy
         )
-        (?=(?:\r?\n){2,}|\Z)             # stop at a blank line (>=2 newlines) or end
+        (?=(?:\r?\n){2,}(?:[ \t]*(?:[#|]|!\[|---(?!-*\s*continued)))|\Z)  # stop at a blank line if followed by structural block (#, |, ![, ---) or EOF
         """,
         re.MULTILINE | re.VERBOSE,
     )
@@ -481,10 +534,18 @@ def _process_new_figure_format(text: MarkdownContent, is_supplementary: bool = F
             logger.warning(f"Failed to parse figure attributes '{attr_string}': {e}")
             return m.group(0)
 
+        main_cap, cont_cap, cont_hdr = extract_continued_caption(caption_text)
         try:
             # Resolve generated figure paths (.mmd, .py, .R) to output format (.pdf)
             resolved_path = resolve_generated_figure_path(path)
-            return create_latex_figure_environment(resolved_path, caption_text, attributes, is_supplementary)
+            return create_latex_figure_environment(
+                resolved_path,
+                main_cap,
+                attributes,
+                is_supplementary,
+                continued_caption=cont_cap,
+                continued_header=cont_hdr,
+            )
         except (ValueError, KeyError, TypeError) as e:
             # If LaTeX emission fails due to invalid parameters, log and keep original block
             from ..core.logging_config import get_logger
@@ -676,11 +737,19 @@ def _process_figure_with_attributes(text: MarkdownContent, is_supplementary: boo
         else:
             combined_caption = caption_text
 
+        main_cap, cont_cap, cont_hdr = extract_continued_caption(combined_caption)
         # Parse attributes
         attributes = parse_figure_attributes(attr_string)
         # Resolve generated figure paths (.mmd, .py, .R) to output format (.pdf)
         resolved_path = resolve_generated_figure_path(path)
-        return create_latex_figure_environment(resolved_path, combined_caption, attributes, is_supplementary)
+        return create_latex_figure_environment(
+            resolved_path,
+            main_cap,
+            attributes,
+            is_supplementary,
+            continued_caption=cont_cap,
+            continued_header=cont_hdr,
+        )
 
     text = re.sub(
         r"!\[([^\]]*)\]\(([^)]+)\)\s*\n\s*\{([^}]+)\}\s*(.*?)(?=\n\n|\Z)",

--- a/src/rxiv_maker/exporters/docx_content_processor.py
+++ b/src/rxiv_maker/exporters/docx_content_processor.py
@@ -686,9 +686,22 @@ class DocxContentProcessor:
                 while next_i < len(lines):
                     line = lines[next_i].strip()
 
-                    # Stop at empty line
+                    # Stop at empty line if next non-empty line is a structural element (# heading, ![ figure, etc.)
                     if not line:
-                        break
+                        check_i = next_i + 1
+                        while check_i < len(lines) and not lines[check_i].strip():
+                            check_i += 1
+                        if check_i >= len(lines):
+                            break
+                        next_block = lines[check_i].strip()
+                        if (
+                            next_block.startswith("![")
+                            or re.match(r"^#{1,6}\s+", next_block)
+                            or re.match(r"\{#(fig|sfig|stable|snote):", next_block)
+                        ):
+                            break
+                        next_i += 1
+                        continue
 
                     # Stop at next figure
                     if line.startswith("!["):
@@ -706,13 +719,19 @@ class DocxContentProcessor:
                     next_i += 1
 
                 # Combine caption lines - keep markdown for inline formatting
-                caption = " ".join(caption_lines)
+                caption = "\n\n".join(caption_lines)
+
+        from rxiv_maker.converters.figure_processor import extract_continued_caption
+
+        main_cap, cont_cap, cont_hdr = extract_continued_caption(caption)
 
         return {
             "type": "figure",
             "path": image_path,
             "alt": alt_text,
-            "caption": caption,
+            "caption": main_cap,
+            "continued_caption": cont_cap,
+            "continued_header": cont_hdr,
             "label": label,
             "is_supplementary": is_supplementary,
         }, next_i

--- a/src/rxiv_maker/exporters/docx_writer.py
+++ b/src/rxiv_maker/exporters/docx_writer.py
@@ -870,6 +870,63 @@ class DocxWriter:
             # Add spacing after figure (reduced from 12 to 6 for compactness)
             caption_para.paragraph_format.space_after = Pt(6)
 
+        # Add continued caption if present
+        cont_caption = section.get("continued_caption")
+        if cont_caption:
+            cont_para = doc.add_paragraph()
+            cont_para.alignment = WD_ALIGN_PARAGRAPH.JUSTIFY
+            cont_para.paragraph_format.space_before = Pt(3)
+
+            hdr = section.get("continued_header") or "(Continued from previous page.)"
+            hdr_run = cont_para.add_run(f"{hdr} ")
+            hdr_run.bold = True
+            hdr_run.font.size = Pt(8)
+
+            from rxiv_maker.exporters.docx_content_processor import DocxContentProcessor
+
+            processor = DocxContentProcessor()
+            caption_runs = processor._parse_inline_formatting(cont_caption, {})
+
+            for run_data in caption_runs:
+                if run_data["type"] == "text":
+                    text = run_data["text"]
+                    run = cont_para.add_run(text)
+                    run.font.size = Pt(8)
+
+                    if run_data.get("bold"):
+                        run.bold = True
+                    if run_data.get("italic"):
+                        run.italic = True
+                    if run_data.get("subscript"):
+                        run.font.subscript = True
+                    if run_data.get("superscript"):
+                        run.font.superscript = True
+                    if run_data.get("code"):
+                        run.font.name = "Courier New"
+                    if run_data.get("xref"):
+                        xref_type = run_data.get("xref_type", "cite")
+                        self._apply_highlight(run, self.get_xref_color(xref_type))
+                    if run_data.get("highlight_yellow"):
+                        self._apply_highlight(run, WD_COLOR_INDEX.YELLOW)
+                elif run_data["type"] == "inline_equation":
+                    latex_content = run_data.get("latex", "")
+                    self._add_inline_equation(cont_para, latex_content)
+                elif run_data["type"] == "inline_comment":
+                    if not self.hide_comments:
+                        comment_text = run_data["text"]
+                        run = cont_para.add_run(f"[Comment: {comment_text}]")
+                        self._apply_highlight(run, WD_COLOR_INDEX.GRAY_25)
+                        run.italic = True
+                        run.font.size = Pt(8)
+                elif run_data["type"] == "citation":
+                    cite_num = run_data["number"]
+                    run = cont_para.add_run(f"[{cite_num}]")
+                    run.bold = True
+                    run.font.size = Pt(8)
+                    self._apply_highlight(run, WD_COLOR_INDEX.YELLOW)
+
+            cont_para.paragraph_format.space_after = Pt(6)
+
     def _add_table(self, doc: Document, section: Dict[str, Any]):
         """Add table to document.
 

--- a/tests/unit/test_figure_legend_continuation.py
+++ b/tests/unit/test_figure_legend_continuation.py
@@ -1,0 +1,125 @@
+"""Unit tests for figure legend continuation functionality (Issue #324)."""
+
+from rxiv_maker.converters.figure_processor import (
+    convert_figures_to_latex,
+    create_latex_figure_environment,
+    extract_continued_caption,
+)
+from rxiv_maker.exporters.docx_content_processor import DocxContentProcessor
+
+
+class TestExtractContinuedCaption:
+    """Test extract_continued_caption helper."""
+
+    def test_no_continuation(self):
+        caption = "**Figure Title.** Caption text describing panels A and B."
+        main, cont, hdr = extract_continued_caption(caption)
+        assert main == caption
+        assert cont is None
+        assert hdr == "(Continued from previous page.)"
+
+    def test_basic_continuation_separator(self):
+        caption = (
+            "**Figure Title.**\n\n(**A**) Panel A details.\n\n---continued---\n\n(**B**) Panel B details on next page."
+        )
+        main, cont, hdr = extract_continued_caption(caption)
+        assert "**Figure Title.**" in main
+        assert "(**A**) Panel A details." in main
+        assert cont == "(**B**) Panel B details on next page."
+        assert hdr == "(Continued from previous page.)"
+
+    def test_custom_continuation_header(self):
+        caption = "**Figure Title.** Panel A text.\n---continued: (Continued from page 1)---\nPanel B text on page 2."
+        main, cont, hdr = extract_continued_caption(caption)
+        assert main == "**Figure Title.** Panel A text."
+        assert cont == "Panel B text on page 2."
+        assert hdr == "(Continued from page 1)"
+
+
+class TestCreateLatexFigureEnvironmentContinuation:
+    """Test LaTeX generation with figure legend continuation."""
+
+    def test_create_latex_environment_with_continuation(self):
+        latex = create_latex_figure_environment(
+            path="FIGURES/Fig1.png",
+            caption="**Title.** Main caption text.",
+            attributes={"id": "fig:test", "tex_position": "p"},
+            continued_caption="(**E--H**) Continued legend text on next page.",
+            continued_header="(Continued from previous page.)",
+        )
+        # Main figure environment checks
+        assert r"\begin{figure*}[p!]" in latex
+        assert r"\caption{\textbf{Title.} Main caption text.}" in latex
+        assert r"\label{fig:test}" in latex
+        assert r"\end{figure*}" in latex
+
+        # Continuation figure environment checks
+        assert r"\begin{figure*}[t!]" in latex
+        assert r"\ContinuedFloat" in latex
+        assert (
+            r"\caption[]{\textbf{(Continued from previous page.)} (\textbf{E--H}) Continued legend text on next page.}"
+            in latex
+        )
+
+    def test_convert_figures_to_latex_with_continued_separator(self):
+        markdown = (
+            "![](FIGURES/Figure1.png)\n"
+            '{#fig:cell-migration width="0.70" tex_position="p"} **Cell migration is regulated by matrix organisation.**\n\n'
+            "(**A**) Overview of the experimental workflow.\n\n"
+            "---continued---\n\n"
+            "(**E--H**) Time-lapse imaging and analysis of protrusion dynamics.\n\n"
+            "## Next Section"
+        )
+        result = convert_figures_to_latex(markdown)
+
+        assert r"\begin{figure*}" in result
+        assert r"\label{fig:cell-migration}" in result
+        assert r"\ContinuedFloat" in result
+        assert (
+            r"\caption[]{\textbf{(Continued from previous page.)} (\textbf{E--H}) Time-lapse imaging and analysis of protrusion dynamics.}"
+            in result
+        )
+
+
+class TestAttributeContinuedCaption:
+    """Test attribute block specifying continued_caption."""
+
+    def test_attribute_continued_caption(self):
+        markdown = (
+            "![](FIGURES/Figure1.png)\n"
+            '{#fig:attr-test width="0.8" continued_caption="(**C**) Extra details on next page."} **Main title.** Panel A details.'
+        )
+        result = convert_figures_to_latex(markdown)
+
+        assert r"\begin{figure}" in result or r"\begin{figure*}" in result
+        assert r"\ContinuedFloat" in result
+        assert "Extra details on next page." in result
+
+
+class TestDocxContentProcessorContinuation:
+    """Test DOCX content processor parsing of continued captions."""
+
+    def test_parse_figure_with_continued_caption(self):
+        lines = [
+            "![](FIGURES/Fig1.png)",
+            '{#fig:cell-migration width="0.7"} **Cell migration.**',
+            "",
+            "(**A**) Overview.",
+            "",
+            "---continued---",
+            "",
+            "(**E**) Time-lapse.",
+            "",
+            "## Section Title",
+        ]
+        processor = DocxContentProcessor()
+        doc_structure = processor.parse("\n".join(lines), {})
+
+        fig_sections = [s for s in doc_structure["sections"] if s.get("type") == "figure"]
+        assert len(fig_sections) == 1
+        fig = fig_sections[0]
+
+        assert "**Cell migration.**" in fig["caption"]
+        assert "(**A**) Overview." in fig["caption"]
+        assert fig["continued_caption"] == "(**E**) Time-lapse."
+        assert fig["continued_header"] == "(Continued from previous page.)"


### PR DESCRIPTION
## Summary
Adds support for splitting long multi-panel figure legends across page boundaries using  or  separators in Markdown captions.

## Key Changes
- **LaTeX Exporter**: Emits a  figure float placed at the top of the next page (), preserving the original figure counter without duplicate List of Figures entries.
- **DOCX Exporter**: Renders the continued caption as a formatted follow-up paragraph with the continuation header.
- **Parser**: Extracted caption blocks support multi-paragraph figure captions and continuation separators.

Closes #324.