### PR TITLE
fix: render arXiv venue in bibliography entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.4] - 2026-09-02
+
+### Fixed
+- Bibliography entries no longer drop the arXiv venue. `rxiv_maker_style.bst` declared
+  neither `eprint` nor `archiveprefix`, so any `@misc` preprint reference printed as a
+  bare title, author and year followed by a DOI. Google Scholar matches a reference to
+  a target record on the venue token and identifier, so the missing venue weakened
+  citation clustering for every arXiv reference in a manuscript, including the injected
+  rxiv-maker self-citation. References now render `arXiv:2508.00836`, and honour
+  `archivePrefix` for other servers (for example `bioRxiv:2026.01.01.123456`).
+
 ## [1.23.3] - 2026-08-10
 
 ### Fixed

--- a/src/rxiv_maker/__version__.py
+++ b/src/rxiv_maker/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "1.23.3"
+__version__ = "1.23.4"

--- a/src/tex/style/rxiv_maker_style.bst
+++ b/src/tex/style/rxiv_maker_style.bst
@@ -46,6 +46,7 @@
  %
 ENTRY
   { address
+    archiveprefix
     author
     booktitle
     chapter
@@ -53,6 +54,7 @@ ENTRY
     eid
     edition
     editor
+    eprint
     howpublished
     institution
     isbn
@@ -293,6 +295,17 @@ FUNCTION {format.doi}
 { doi empty$
     { "" }
     { new.block "\doi{" doi * "}" * }
+  if$
+}
+
+FUNCTION {format.eprint}
+{ eprint empty$
+    { "" }
+    { archiveprefix empty$
+        { new.block "arXiv:" eprint * }
+        { new.block archiveprefix ":" * eprint * }
+      if$
+    }
   if$
 }
 
@@ -925,6 +938,7 @@ FUNCTION {misc}
   howpublished new.block.checka
   howpublished output
   format.date output
+  format.eprint output
   format.issn output
   format.doi output
   new.block

--- a/tests/unit/test_bst_eprint_venue.py
+++ b/tests/unit/test_bst_eprint_venue.py
@@ -1,0 +1,62 @@
+"""Regression test: the bibliography style must render the arXiv venue.
+
+Google Scholar clusters a reference to a target record using the venue token
+and identifier. A reference printed as bare title/author/year is the weakest
+form to match, so dropping `eprint` silently costs citations.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+BST = Path(__file__).parents[2] / "src" / "tex" / "style" / "rxiv_maker_style.bst"
+
+BIB = """\
+@misc{with_eprint,
+      title={A preprint with an eprint field},
+      author={Bruno M. Saraiva and Ricardo Henriques},
+      year={2025},
+      eprint={2508.00836},
+      archivePrefix={arXiv},
+      doi={10.48550/arXiv.2508.00836},
+}
+
+@misc{without_eprint,
+      title={A misc entry with no eprint field},
+      author={Jane Doe},
+      year={2024},
+}
+"""
+
+AUX = """\
+\\relax
+\\citation{with_eprint}
+\\citation{without_eprint}
+\\bibstyle{rxiv_maker_style}
+\\bibdata{refs}
+"""
+
+
+def test_bst_declares_eprint_fields():
+    """ENTRY must declare eprint and archiveprefix, else BibTeX ignores them."""
+    text = BST.read_text(encoding="utf-8")
+    assert "eprint" in text, "bst lost its eprint field declaration"
+    assert "archiveprefix" in text
+    assert "format.eprint output" in text, "misc entry no longer emits the venue"
+
+
+@pytest.mark.skipif(shutil.which("bibtex") is None, reason="bibtex not installed")
+def test_bst_eprint_venue(tmp_path):
+    """A cited @misc with eprint must print an arXiv venue token."""
+    shutil.copy(BST, tmp_path / BST.name)
+    (tmp_path / "refs.bib").write_text(BIB, encoding="utf-8")
+    (tmp_path / "test.aux").write_text(AUX, encoding="utf-8")
+
+    subprocess.run(["bibtex", "test"], cwd=tmp_path, check=True, capture_output=True)
+    bbl = (tmp_path / "test.bbl").read_text(encoding="utf-8")
+
+    assert "arXiv:2508.00836" in bbl
+    # An entry without eprint must stay clean, with no stray separator.
+    assert "arXiv:" not in bbl.split("without_eprint")[-1]


### PR DESCRIPTION
## Problem

`src/tex/style/rxiv_maker_style.bst` declared neither `eprint` nor `archiveprefix`. Its `FUNCTION {misc}` reads authors, title, `howpublished`, date, issn, doi, note, so both fields were silently discarded.

The canonical injected self-citation sets `eprint` and `archivePrefix` and sets neither `howpublished` nor `journal`, so it printed with no venue at all:

```
Bruno M. Saraiva, António D. Brito, Guillaume Jaquemet, and Ricardo Henriques.
Rxiv-maker: an automated template engine for streamlined scientific
publications, 2025.
doi: 10.48550/arXiv.2508.00836.
```

Google Scholar matches a reference to a target record using the venue token and identifier, and its [inclusion guidelines](https://scholar.google.com/scholar/inclusion.html) warn that "incorrect identification of references could lead to exclusion of your papers from Google Scholar or to low ranking". A bare title/author/year string is the weakest form to cluster on.

This affected **every** arXiv reference in a manuscript, not only the self-citation: 5 `eprint` entries in `manuscript-maicrobe`, 5 in `manuscript-vlab4mic`, 7 in `manuscript-rxiv-maker`, with `howpublished` appearing zero times in any of them.

## Change

- `ENTRY` declares `archiveprefix` and `eprint`.
- New `FUNCTION {format.eprint}`, following the existing `format.doi` and `format.issn` conventions.
- `FUNCTION {misc}` emits it after the date.

References now render `arXiv:2508.00836`, and honour `archivePrefix` for other servers (`bioRxiv:2026.01.01.123456`). Entries without `eprint` are unchanged, with no stray separator.

`bst_generator.py` reads this file as a template and rewrites only the author format string, so the change propagates to all three name formats.

## Testing

`tests/unit/test_bst_eprint_venue.py` runs BibTeX against the style and asserts the venue is present, with a control entry that has no `eprint`. Confirmed to fail on the unpatched style and pass on the patched one. The structural half runs everywhere; the BibTeX half skips when `bibtex` is absent.

Unit suite shows the same 11 pre-existing failures before and after this change (1658 to 1660 passed, the difference being the two new tests), so no regression.

## Scope

Only future builds gain the venue. Anything already posted keeps the venue-less reference until its next revision, and Scholar takes 6 to 9 months to re-cluster updated records.
